### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - id: upload
         name: Upload Coverage Report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/generate_coverage_pr.yaml
+++ b/.github/workflows/generate_coverage_pr.yaml
@@ -54,13 +54,13 @@ jobs:
       # Triggered sub-workflow is not able to detect the original commit/PR which is available
       # in this workflow.
       - name: Store PR number
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: pr_number
           path: pr_number.txt
 
       - name: Store commit SHA
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: commit_sha
           path: commit_sha.txt
@@ -69,7 +69,7 @@ jobs:
       # is executed by a different workflow `upload_coverage.yml`. The reason for this
       # split is because `on.pull_request` workflows don't have access to secrets.
       - name: Store coverage report in artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: codecov_report
           path: ./codecov.json

--- a/.github/workflows/upload_coverage_pr.yaml
+++ b/.github/workflows/upload_coverage_pr.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: "Download existing coverage report"
         id: prepare_report
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             var fs = require('fs');
@@ -102,7 +102,7 @@ jobs:
           path: repo_root
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/packages/dht/src/routing/node.rs
+++ b/packages/dht/src/routing/node.rs
@@ -356,20 +356,20 @@ mod tests {
     fn positive_good_status_ordering() {
         assert!(NodeStatus::Good > NodeStatus::Questionable);
         assert!(NodeStatus::Good > NodeStatus::Bad);
-        assert!(NodeStatus::Good == NodeStatus::Good);
+        assert_eq!(NodeStatus::Good, NodeStatus::Good);
     }
 
     #[test]
     fn positive_questionable_status_ordering() {
         assert!(NodeStatus::Questionable > NodeStatus::Bad);
         assert!(NodeStatus::Questionable < NodeStatus::Good);
-        assert!(NodeStatus::Questionable == NodeStatus::Questionable);
+        assert_eq!(NodeStatus::Questionable, NodeStatus::Questionable);
     }
 
     #[test]
     fn positive_bad_status_ordering() {
         assert!(NodeStatus::Bad < NodeStatus::Good);
         assert!(NodeStatus::Bad < NodeStatus::Questionable);
-        assert!(NodeStatus::Bad == NodeStatus::Bad);
+        assert_eq!(NodeStatus::Bad, NodeStatus::Bad);
     }
 }

--- a/packages/util/src/contiguous.rs
+++ b/packages/util/src/contiguous.rs
@@ -36,7 +36,7 @@ where
     }
 
     fn clear(&mut self) {
-        self.truncate(0);
+        self.clear();
     }
 
     fn write(&mut self, data: &[T]) {

--- a/packages/util/src/sha/mod.rs
+++ b/packages/util/src/sha/mod.rs
@@ -178,7 +178,7 @@ mod tests {
         let xor_hash = zero_bits ^ one_bits;
 
         let leading_zeroes = xor_hash.bits().take_while(|&n| n == XorRep::Same).count();
-        assert!(leading_zeroes == 0);
+        assert_eq!(leading_zeroes, 0);
     }
 
     #[test]
@@ -189,7 +189,7 @@ mod tests {
         let xor_hash = first_one_bits ^ second_one_bits;
 
         let leading_zeroes = xor_hash.bits().take_while(|&n| n == XorRep::Same).count();
-        assert!(leading_zeroes == (super::SHA_HASH_LEN * 8));
+        assert_eq!(leading_zeroes, (super::SHA_HASH_LEN * 8));
     }
 
     #[test]
@@ -203,7 +203,7 @@ mod tests {
         let xor_hash = zero_bits ^ mostly_one_bits;
 
         let leading_zeroes = xor_hash.bits().take_while(|&n| n == XorRep::Same).count();
-        assert!(leading_zeroes == 1);
+        assert_eq!(leading_zeroes, 1);
     }
 
     #[test]
@@ -217,7 +217,7 @@ mod tests {
         let xor_hash = zero_bits ^ mostly_zero_bits;
 
         let leading_zeroes = xor_hash.bits().take_while(|&n| n == XorRep::Same).count();
-        assert!(leading_zeroes == 0);
+        assert_eq!(leading_zeroes, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Update GitHub Actions versions used in CI workflows to their latest releases.

## Changes

- `codecov/codecov-action` v5 → v6
- `actions/upload-artifact` v6 → v7
- `actions/github-script` v8 → v9

These are drop-in version bumps with no configuration changes required.