### PR TITLE
chore: bump MSRV from 1.85 to 1.88

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ keywords = ["bittorrent"]
 license = "Apache-2.0"
 publish = false                                                                                     # until we decide where to publish.
 repository = "https://github.com/torrust/torrust-bittorrent"
-rust-version = "1.85"
+rust-version = "1.88"
 version = "1.0.0-alpha.1"
 
 [profile.bench]

--- a/examples/get_metadata/Cargo.toml
+++ b/examples/get_metadata/Cargo.toml
@@ -11,6 +11,7 @@ homepage.workspace = true
 license.workspace = true
 publish.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 version.workspace = true
 
 [lints]

--- a/examples/simple_torrent/Cargo.toml
+++ b/examples/simple_torrent/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 repository.workspace = true
 version.workspace = true

--- a/packages/bencode/Cargo.toml
+++ b/packages/bencode/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 repository.workspace = true
 version.workspace = true

--- a/packages/dht/Cargo.toml
+++ b/packages/dht/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 repository.workspace = true
 version.workspace = true

--- a/packages/disk/Cargo.toml
+++ b/packages/disk/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 repository.workspace = true
 version.workspace = true

--- a/packages/handshake/Cargo.toml
+++ b/packages/handshake/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 repository.workspace = true
 version.workspace = true

--- a/packages/magnet/Cargo.toml
+++ b/packages/magnet/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 repository.workspace = true
 version.workspace = true
@@ -23,4 +24,3 @@ util = { path = "../util" }
 
 base32 = "0"
 url = "2"
-

--- a/packages/metainfo/Cargo.toml
+++ b/packages/metainfo/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 repository.workspace = true
 version.workspace = true

--- a/packages/peer/Cargo.toml
+++ b/packages/peer/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 repository.workspace = true
 version.workspace = true

--- a/packages/select/Cargo.toml
+++ b/packages/select/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 repository.workspace = true
 version.workspace = true

--- a/packages/util/Cargo.toml
+++ b/packages/util/Cargo.toml
@@ -11,6 +11,7 @@ edition.workspace = true
 homepage.workspace = true
 license.workspace = true
 publish.workspace = true
+rust-version.workspace = true
 
 repository.workspace = true
 version.workspace = true


### PR DESCRIPTION
Closes #71

## Summary

Bumps the minimum supported Rust version (MSRV) from `1.85` to `1.88` in the workspace `Cargo.toml`, aligning this repository with Torrust Tracker and Torrust Index.

## Changes

### `Cargo.toml`

- `rust-version = "1.85"` → `rust-version = "1.88"`

## Notes

No CI workflow changes were required — all workflows use `stable`/`nightly` toolchain references dynamically rather than pinning a specific version number.