### PR TITLE
chore: setup package publishing infrastructure (#80)

### DIFF
--- a/.github/skills/dev/maintenance/release-package/SKILL.md
+++ b/.github/skills/dev/maintenance/release-package/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: release-package
+description: End-to-end workflow for releasing a new version of a crate from the torrust-bittorrent workspace to crates.io. Covers version bumping, pre-flight checks, first-time publish setup, tagging, publishing, and GitHub release creation. Use when releasing any crate in packages/. Triggers on "release crate", "publish package", "bump version", "release torrust-<name>".
+metadata:
+  author: torrust
+  version: "1.0"
+  semantic-links:
+    related-artifacts:
+      - AGENTS.md
+      - Cargo.toml
+      - docs/adrs/20260605103740_crate_publishing_and_versioning.md
+      - .github/skills/dev/git-workflow/create-feature-branch/SKILL.md
+      - .github/skills/dev/git-workflow/open-pull-request/SKILL.md
+      - .github/skills/dev/git-workflow/run-linters/SKILL.md
+---
+
+# Releasing a Package
+
+Use this workflow when publishing a new version of a crate from `packages/` to crates.io.
+
+## Publishing Policy (read first)
+
+- **Publish on demand**: only publish a crate when it is actively consumed by another Torrust
+  project and has been validated in production use.
+- **First release**: before the first publish of a crate, change `publish = false` to
+  `publish = true` in its `packages/<name>/Cargo.toml`.
+- **Independent versions**: each crate is versioned independently. Releasing one crate does not
+  require bumping any other crate's version.
+- All crates start at `0.1.0`. Follow [SemVer](https://semver.org/) for all subsequent releases.
+
+See `docs/adrs/20260605103740_crate_publishing_and_versioning.md` for the full rationale.
+
+## Skill Links
+
+- `AGENTS.md`
+- `.github/skills/dev/git-workflow/create-feature-branch/SKILL.md`
+- `.github/skills/dev/git-workflow/open-pull-request/SKILL.md`
+- `.github/skills/dev/git-workflow/run-linters/SKILL.md`
+
+## Workflow
+
+### Step 1: Create a release branch
+
+Create a dedicated branch for the release following the branching convention.
+
+```bash
+git checkout develop
+git fetch origin
+git pull --ff-only origin develop
+git checkout -b chore/release-torrust-<name>-vX.Y.Z
+```
+
+Example: `chore/release-torrust-bencode-v0.2.0`
+
+### Step 2: Determine the new version
+
+Follow [SemVer](https://semver.org/):
+
+| Change type                                                  | Version bump              |
+| ------------------------------------------------------------ | ------------------------- |
+| Bug fix, documentation, internal refactor with no API change | PATCH (`0.1.0` → `0.1.1`) |
+| New backwards-compatible API                                 | MINOR (`0.1.0` → `0.2.0`) |
+| Breaking API change                                          | MAJOR (`0.1.0` → `1.0.0`) |
+
+Check the current version:
+
+```bash
+grep '^version' packages/<name>/Cargo.toml
+```
+
+### Step 3: Enable publishing (first release only)
+
+If this is the first public release of the crate, flip the publish flag in
+`packages/<name>/Cargo.toml`:
+
+```toml
+# Before:
+publish = false  # override with publish = true when ready for a public release
+
+# After:
+publish = true
+```
+
+### Step 4: Bump the version
+
+Update the `version` field in `packages/<name>/Cargo.toml`:
+
+```toml
+version = "X.Y.Z"
+```
+
+If other crates in the workspace depend on the released crate, update their `Cargo.toml` to
+reference the new version (if using a specific version rather than a path dependency).
+
+### Step 5: Update the changelog
+
+If `packages/<name>/CHANGELOG.md` exists, add an entry for the new version:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+
+- ...
+
+### Changed
+
+- ...
+
+### Fixed
+
+- ...
+```
+
+If no `CHANGELOG.md` exists yet, create one following the
+[Keep a Changelog](https://keepachangelog.com/) format.
+
+### Step 6: Dry-run publish check
+
+Verify the crate packages correctly before committing:
+
+```bash
+cargo publish -p torrust-<name> --dry-run
+```
+
+Fix any errors before proceeding.
+
+### Step 7: Run all quality checks
+
+```bash
+linter all
+cargo +nightly fmt
+cargo clippy --workspace --all-targets --all-features
+cargo nextest run --workspace --all-targets --all-features
+cargo test --doc --workspace
+```
+
+All checks must pass before committing.
+
+### Step 8: Commit the release
+
+```bash
+git add packages/<name>/Cargo.toml packages/<name>/CHANGELOG.md  # add Cargo.lock too if changed
+git commit -m "chore(release): release torrust-<name> vX.Y.Z"
+```
+
+### Step 9: Open a PR and get it merged
+
+Open a PR targeting `develop` in `torrust/torrust-bittorrent`. Follow the standard PR workflow
+in `.github/skills/dev/git-workflow/open-pull-request/SKILL.md`.
+
+The PR title should match the commit message:
+`chore(release): release torrust-<name> vX.Y.Z`
+
+Wait for CI to pass and the PR to be merged before continuing.
+
+### Step 10: Tag the merge commit
+
+After the PR is merged, tag the merge commit on `develop`:
+
+```bash
+git checkout develop
+git pull --ff-only origin develop
+git tag torrust-<name>-vX.Y.Z
+git push origin torrust-<name>-vX.Y.Z
+```
+
+Tag format: `torrust-<name>-vX.Y.Z` (e.g. `torrust-bencode-v0.2.0`).
+
+Each crate has its own tag namespace; multiple crate tags can coexist on the same commit or
+on different commits.
+
+### Step 11: Publish to crates.io
+
+```bash
+cargo publish -p torrust-<name>
+```
+
+Verify the release appears at `https://crates.io/crates/torrust-<name>`.
+
+### Step 12: Open a GitHub release
+
+Create a GitHub release pointing to the tag:
+
+- **Tag**: `torrust-<name>-vX.Y.Z`
+- **Title**: `torrust-<name> vX.Y.Z`
+- **Body**: copy the changelog entry for this version.
+
+Each crate has its own independent GitHub release. Multiple releases from different crates can
+coexist in the same repository.
+
+## Constraints
+
+- Do not publish a crate that still has `publish = false` in its `Cargo.toml`.
+- Do not skip the `--dry-run` step; it catches packaging errors before they reach crates.io.
+- Do not publish from a feature branch; always publish from the tag on `develop`.
+- Do not force-push or amend the tagged commit after publishing.
+- Do not bump versions of crates that are not being released in this PR.
+
+## Related Skills
+
+- Create a feature branch: `.github/skills/dev/git-workflow/create-feature-branch/SKILL.md`
+- Open a pull request: `.github/skills/dev/git-workflow/open-pull-request/SKILL.md`
+- Run linters: `.github/skills/dev/git-workflow/run-linters/SKILL.md`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,14 @@ edition = "2024"
 homepage = "https://github.com/torrust/torrust-bittorrent"
 keywords = [ "bittorrent" ]
 license = "Apache-2.0"
-publish = false                                                                                       # until we decide where to publish.
+# publish = false is the workspace default inherited by example crates.
+# Each crate in packages/ sets its own publish and version fields explicitly.
+# A crate is only published to crates.io when it is actively consumed by another
+# Torrust project and has been validated in production use. Flip publish = true
+# in the crate's own Cargo.toml when it is ready for a public release.
+publish = false
 repository = "https://github.com/torrust/torrust-bittorrent"
 rust-version = "1.88"
-version = "1.0.0-alpha.1"
 
 [profile.bench]
 codegen-units = 1

--- a/docs/adrs/20260605103740_crate_publishing_and_versioning.md
+++ b/docs/adrs/20260605103740_crate_publishing_and_versioning.md
@@ -1,0 +1,93 @@
+---
+doc-type: adr
+status: accepted
+last-updated-utc: 2026-06-05 10:37
+semantic-links:
+  skill-links:
+    - release-package
+  related-issues:
+    - https://github.com/torrust/torrust-bittorrent/issues/80
+    - https://github.com/torrust/torrust-bittorrent/issues/64
+  related-artifacts:
+    - Cargo.toml
+    - packages/bencode/Cargo.toml
+    - packages/dht/Cargo.toml
+    - packages/disk/Cargo.toml
+    - packages/handshake/Cargo.toml
+    - packages/magnet/Cargo.toml
+    - packages/metainfo/Cargo.toml
+    - packages/peer/Cargo.toml
+    - packages/select/Cargo.toml
+    - packages/util/Cargo.toml
+    - .github/skills/dev/maintenance/release-package/SKILL.md
+    - docs/issues/0080-setup-package-publishing-infrastructure.md
+---
+
+# Crate Publishing and Versioning Strategy
+
+- Date: 2026-06-05
+- References: [issue #80](https://github.com/torrust/torrust-bittorrent/issues/80),
+  [torrust/torrust-tracker DECISIONS.md DEC-02/DEC-03/DEC-04](https://github.com/torrust/torrust-tracker/blob/develop/docs/issues/open/1669-overhaul-packages/DECISIONS.md)
+
+## Description
+
+The `torrust-bittorrent` workspace is a collection of library crates forked from the unmaintained
+[GGist/bip-rs](https://github.com/GGist/bip-rs) project. Multiple questions needed to be
+answered before any crate could be published or consumed by other Torrust projects:
+
+1. **What should crates be named?** The workspace covers BitTorrent infrastructure. Should the
+   prefix be `torrust-bittorrent-` (project-scoped) or just `torrust-` (organisation-scoped)?
+2. **When should crates be published?** Old versions under the original GGist names already
+   exist on crates.io. Publishing renamed crates prematurely would add noise before they are
+   validated in production.
+3. **How should versions be managed?** A single shared workspace version couples unrelated
+   crates. Independent versioning keeps each crate's release history clean.
+
+## Agreement
+
+### Naming — `torrust-` prefix, folder name without prefix
+
+Adopted from DEC-02 and DEC-04 of the Torrust Tracker overhaul DECISIONS.md:
+
+- Crates are named `torrust-<short-name>` (e.g. `torrust-bencode`, `torrust-dht`).
+  The extra `bittorrent` segment adds length without adding meaningful disambiguation.
+- Package folder names under `packages/` match the crate name **with the prefix removed**
+  (e.g. crate `torrust-bencode` → folder `packages/bencode`). This keeps folder names short
+  and directly inferrable from the crate name.
+- The prefix indicates Torrust organisation ownership, not expected reusability (DEC-03).
+  Tracker-domain crates use `torrust-tracker-`; organisation-level shared crates use `torrust-`.
+
+### Publishing — publish on demand
+
+- `publish = false` is the workspace default (set in `[workspace.package]`).
+- Each crate in `packages/` sets `publish = false` explicitly with a comment.
+- A crate is only flipped to `publish = true` and released to crates.io when:
+  - it is actively consumed by another Torrust project, **and**
+  - it has been validated in production use.
+- Rationale: these crates are forks of unmaintained upstream code. Publishing before validation
+  would pollute crates.io with potentially stale or incomplete crates under new names.
+
+### Versioning — independent per-crate versions
+
+- The shared `version` field is removed from `[workspace.package]`.
+- Every crate in `packages/` carries its own explicit `version` field.
+- All crates start at `0.1.0` regardless of prior crates.io history under different names
+  (old names are different crate identities; their version history does not carry over).
+- Subsequent releases follow [SemVer](https://semver.org/): PATCH for fixes, MINOR for
+  new backwards-compatible API, MAJOR for breaking changes.
+- Each crate is released independently; releasing one crate does not require bumping any other.
+
+## Tradeoffs Accepted
+
+- Each `packages/<name>/Cargo.toml` must explicitly declare `version` and `publish` fields
+  (slightly more maintenance overhead than inheriting from `[workspace.package]`).
+- There is no single "workspace version" signal visible to external consumers; each crate's
+  version is the only relevant signal.
+- Crates that are not yet published are still importable via path dependencies within the
+  workspace, which is the intended usage until a crate is production-validated.
+
+## Affected Code
+
+- `Cargo.toml` — `[workspace.package]` publish and version policy
+- `packages/*/Cargo.toml` — per-crate `version` and `publish` fields
+- `.github/skills/dev/maintenance/release-package/SKILL.md` — release workflow

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -1,0 +1,16 @@
+---
+doc-type: index
+last-updated-utc: 2026-06-05 10:37
+semantic-links:
+  skill-links:
+    - create-adr
+  related-issues: []
+  related-artifacts:
+    - docs/adrs/20260605103740_crate_publishing_and_versioning.md
+---
+
+# ADR Index
+
+| Timestamp                                                           | Date       | Title                                    | Description                                                                                                          |
+| ------------------------------------------------------------------- | ---------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| [20260605103740](20260605103740_crate_publishing_and_versioning.md) | 2026-06-05 | Crate Publishing and Versioning Strategy | Adopts `torrust-` prefix naming, publish-on-demand strategy, and independent per-crate versioning for the workspace. |

--- a/docs/issues/0080-setup-package-publishing-infrastructure.md
+++ b/docs/issues/0080-setup-package-publishing-infrastructure.md
@@ -1,13 +1,13 @@
 ---
 doc-type: issue
 issue-type: task
-status: open
+status: in-review
 priority: p2
 github-issue: 80
 spec-path: docs/issues/0080-setup-package-publishing-infrastructure.md
 branch: chore/setup-package-publishing-infrastructure
 related-pr: null
-last-updated-utc: 2026-06-05 00:00
+last-updated-utc: 2026-06-05 10:42
 semantic-links:
   skill-links:
     - create-adr
@@ -117,7 +117,8 @@ Version choice:
 
 ### 4. Write an ADR for publishing strategy and independent per-crate versioning
 
-Create `docs/adr/0001-crate-publishing-and-versioning.md` documenting:
+Create `docs/adrs/YYYYMMDDHHMMSS_crate_publishing_and_versioning.md` and register it in
+`docs/adrs/index.md` documenting:
 
 - **Context**: this is a library workspace forked from an unmaintained upstream
   ([GGist/bip-rs](https://github.com/GGist/bip-rs)); old versions under the original crate names
@@ -155,19 +156,19 @@ to release a new version of a crate:
 
 ## Acceptance Criteria
 
-- [ ] All crates in `packages/` are renamed to `torrust-<name>` in their `Cargo.toml`.
-- [ ] Folder names under `packages/` are unchanged.
-- [ ] All inter-crate dependency references use the new crate names.
-- [ ] Each crate in `packages/` has an explicit `version` field independent of the workspace
+- [x] All crates in `packages/` are renamed to `torrust-<name>` in their `Cargo.toml`.
+- [x] Folder names under `packages/` are unchanged.
+- [x] All inter-crate dependency references use the new crate names.
+- [x] Each crate in `packages/` has an explicit `version` field independent of the workspace
       default.
-- [ ] `[workspace.package] publish = false` is kept as the default; crates ready to publish
+- [x] `[workspace.package] publish = false` is kept as the default; crates ready to publish
       override it with `publish = true` in their own `Cargo.toml`.
-- [ ] `docs/adr/0001-crate-publishing-and-versioning.md` exists, covers both the
-      publish-on-demand strategy and independent versioning, and is complete.
-- [ ] `.github/skills/dev/maintenance/release-package/SKILL.md` exists and covers all release
+- [x] `docs/adrs/20260605103740_crate_publishing_and_versioning.md` and `docs/adrs/index.md`
+      exist, cover both the publish-on-demand strategy and independent versioning, and are complete.
+- [x] `.github/skills/dev/maintenance/release-package/SKILL.md` exists and covers all release
       steps.
-- [ ] `cargo check --workspace --all-targets --all-features` passes.
-- [ ] `linter all` passes.
+- [x] `cargo check --workspace --all-targets --all-features` passes.
+- [x] `linter all` passes.
 
 ## Out of scope
 

--- a/docs/issues/0080-setup-package-publishing-infrastructure.md
+++ b/docs/issues/0080-setup-package-publishing-infrastructure.md
@@ -16,7 +16,7 @@ semantic-links:
   related-artifacts:
     - Cargo.toml
     - packages/
-    - docs/adr/
+    - docs/adrs/
     - .github/skills/
 ---
 

--- a/docs/issues/0080-setup-package-publishing-infrastructure.md
+++ b/docs/issues/0080-setup-package-publishing-infrastructure.md
@@ -1,0 +1,183 @@
+---
+doc-type: issue
+issue-type: task
+status: open
+priority: p2
+github-issue: 80
+spec-path: docs/issues/0080-setup-package-publishing-infrastructure.md
+branch: chore/setup-package-publishing-infrastructure
+related-pr: null
+last-updated-utc: 2026-06-05 00:00
+semantic-links:
+  skill-links:
+    - create-adr
+    - add-new-skill
+    - write-markdown-docs
+  related-artifacts:
+    - Cargo.toml
+    - packages/
+    - docs/adr/
+    - .github/skills/
+---
+
+# Setup Package Publishing Infrastructure
+
+## Summary
+
+Establish the basic workspace configuration and conventions for managing and publishing crates
+from the `torrust-bittorrent` workspace. This is a prerequisite for importing the updated
+`torrust-tracker-contrib-bencode` crate (issue #64) and for publishing any crate to crates.io.
+
+## Motivation
+
+The workspace currently has `publish = false` as a placeholder and a single shared version
+(`1.0.0-alpha.1`) for all crates. Before importing or releasing any crate we need:
+
+- Agreed naming conventions, informed by the decisions made in the Torrust Tracker overhaul
+  epic (torrust/torrust-tracker#1669, specifically DEC-02, DEC-03, DEC-04).
+- Independent per-crate versioning so that each crate can evolve and be released separately.
+- A documented release workflow so contributors know exactly how to publish a new version.
+- An ADR capturing the reasoning behind these choices.
+
+## Background — applicable decisions from torrust/torrust-tracker DECISIONS.md
+
+| Decision | Summary                                                                                                                        |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| DEC-02   | Use `torrust-` as the default prefix for Torrust organisation crates (not `torrust-bittorrent-`).                              |
+| DEC-03   | The prefix indicates ownership/subdomain, not expected reusability.                                                            |
+| DEC-04   | Package folder names match the crate name with the ownership prefix removed (e.g. crate `torrust-bencode` → folder `bencode`). |
+
+Consequence for this repo: folder names under `packages/` are already correct and stay
+unchanged. Only the `name` field inside each crate's `Cargo.toml` changes.
+
+## Scope
+
+### 1. Define and document the publishing strategy
+
+Not all crates will be published immediately. The strategy is:
+
+- Publish a crate only when it is actively used by another Torrust project (e.g. the tracker).
+  Crates that are not yet consumed externally stay unpublished until they are needed.
+- Rationale: these crates were forked from an unmaintained upstream
+  ([GGist/bip-rs](https://github.com/GGist/bip-rs)); old versions under the original crate names
+  already exist on crates.io. Publishing prematurely under new names adds noise before the code
+  is validated in production use.
+- Keep `publish = false` in `[workspace.package]` as the safe workspace default.
+  Each crate that is ready to publish overrides it with `publish = true` in its own `Cargo.toml`.
+
+**Outcomes of this task:**
+
+1. Update `[workspace.package]` in the root `Cargo.toml`: ensure `publish = false` is present
+   and add an inline comment explaining the publish-on-demand strategy, e.g.:
+
+   ```toml
+   # publish = false is the workspace default.
+   # Each crate in packages/ overrides this with publish = true only when it is
+   # actively consumed by another Torrust project and ready for a public release.
+   publish = false
+   ```
+
+2. Document the rationale in the ADR (see task 4).
+
+### 2. Rename all crates with the `torrust-` prefix
+
+Apply DEC-02 and DEC-04: rename the `name` field in each `packages/<name>/Cargo.toml`.
+Folder names under `packages/` do **not** change.
+
+| Current crate name | New crate name      | Folder (unchanged)   |
+| ------------------ | ------------------- | -------------------- |
+| `bencode`          | `torrust-bencode`   | `packages/bencode`   |
+| `dht`              | `torrust-dht`       | `packages/dht`       |
+| `disk`             | `torrust-disk`      | `packages/disk`      |
+| `handshake`        | `torrust-handshake` | `packages/handshake` |
+| `magnet`           | `torrust-magnet`    | `packages/magnet`    |
+| `metainfo`         | `torrust-metainfo`  | `packages/metainfo`  |
+| `peer`             | `torrust-peer`      | `packages/peer`      |
+| `select`           | `torrust-select`    | `packages/select`    |
+| `util`             | `torrust-util`      | `packages/util`      |
+
+All inter-crate `[dependencies]` references must be updated to use the new crate names.
+All `use`/`extern crate` references inside source files (if any) must be updated too.
+
+### 3. Set an initial version for each crate
+
+Each crate in `packages/` must have an explicit `version` field in its own `Cargo.toml` rather
+than inheriting a shared workspace version.
+
+Version choice:
+
+- Each crate starts at `0.1.0` as its initial workspace version, regardless of any prior
+  crates.io history under different names. The old `torrust-tracker-contrib-bencode` name and
+  its `3.0.0` version belong to a different crate identity; the renamed `torrust-bencode` is a
+  fresh publication under a new name.
+- When a crate is first published to crates.io its version at that point becomes its first
+  public release — the `0.1.0` in the workspace does not need to match any previous history.
+- The shared `[workspace.package] version` field is removed (or kept only as a fallback for
+  example crates that do not publish).
+
+### 4. Write an ADR for publishing strategy and independent per-crate versioning
+
+Create `docs/adr/0001-crate-publishing-and-versioning.md` documenting:
+
+- **Context**: this is a library workspace forked from an unmaintained upstream
+  ([GGist/bip-rs](https://github.com/GGist/bip-rs)); old versions under the original crate names
+  already exist on crates.io. Each crate has an independent API surface and release cadence.
+- **Decisions**:
+  - Every crate in `packages/` carries its own `version` field starting at `0.1.0`; the shared
+    `[workspace.package] version` is not used for publishable crates.
+  - `publish = false` is the workspace default. A crate is only published to crates.io when it
+    is actively consumed by another Torrust project and has been validated in production use.
+- **Rationale**: independent versioning avoids coupling unrelated crates; follows crates.io
+  conventions for library crates; keeps the changelog and release history per-crate.
+  Publish-on-demand avoids polluting crates.io with premature releases of unvalidated forks.
+- **Tradeoffs**: a bit more `Cargo.toml` maintenance overhead; no global "this is the workspace
+  version" signal; contributors must remember to flip `publish = true` when a crate is ready.
+- **References**: DEC-02, DEC-03, DEC-04 from torrust/torrust-tracker DECISIONS.md;
+  torrust/torrust-bittorrent#80.
+
+### 5. Create a release skill
+
+Add `.github/skills/dev/maintenance/release-package/SKILL.md` documenting the end-to-end steps
+to release a new version of a crate:
+
+1. Determine the new version following SemVer.
+2. Update the `version` field in `packages/<name>/Cargo.toml`.
+3. Update `CHANGELOG.md` inside the package (if present).
+4. Run all checks: `linter all`, `cargo +nightly fmt`, `cargo clippy`, `cargo nextest run`.
+5. Commit following Conventional Commits format:
+   `chore(release): release torrust-<name> vX.Y.Z`.
+6. Open a PR, get it merged to `develop`.
+7. Tag the merge commit: `torrust-<name>-vX.Y.Z`.
+8. Publish to crates.io: `cargo publish -p torrust-<name>`.
+9. Open a GitHub release pointing to the crate tag (e.g. `torrust-bencode-v0.1.0`).
+   Each crate gets its own independent GitHub release; multiple releases can coexist
+   in the same repository, one per crate per version.
+
+## Acceptance Criteria
+
+- [ ] All crates in `packages/` are renamed to `torrust-<name>` in their `Cargo.toml`.
+- [ ] Folder names under `packages/` are unchanged.
+- [ ] All inter-crate dependency references use the new crate names.
+- [ ] Each crate in `packages/` has an explicit `version` field independent of the workspace
+      default.
+- [ ] `[workspace.package] publish = false` is kept as the default; crates ready to publish
+      override it with `publish = true` in their own `Cargo.toml`.
+- [ ] `docs/adr/0001-crate-publishing-and-versioning.md` exists, covers both the
+      publish-on-demand strategy and independent versioning, and is complete.
+- [ ] `.github/skills/dev/maintenance/release-package/SKILL.md` exists and covers all release
+      steps.
+- [ ] `cargo check --workspace --all-targets --all-features` passes.
+- [ ] `linter all` passes.
+
+## Out of scope
+
+- Copying the updated `torrust-tracker-contrib-bencode` source code (issue #64).
+- Publishing any crate to crates.io as part of this issue.
+- Renaming the repository or moving crates between workspaces.
+
+## Related
+
+- #64 — Import `torrust-tracker-contrib-bencode` (blocked on this issue).
+- torrust/torrust-tracker#1669 — Overhaul packages epic (source of DEC-02, DEC-03, DEC-04).
+- <https://crates.io/crates/torrust-tracker-contrib-bencode> — v3.0.0.
+- <https://github.com/torrust/torrust-tracker/blob/develop/docs/issues/open/1669-overhaul-packages/DECISIONS.md>

--- a/docs/skills/semantic-skill-link-convention.md
+++ b/docs/skills/semantic-skill-link-convention.md
@@ -24,6 +24,14 @@ Current markers:
 | ------------ | -------------- | -------------------------------------------------------------------------------------- |
 | `skill-link` | `<skill-name>` | This artifact affects the linked skill and should trigger a skill review when changed. |
 
+## Frontmatter Keys
+
+| Key                 | Type                        | Meaning                                                    |
+| ------------------- | --------------------------- | ---------------------------------------------------------- |
+| `skill-links`       | list of skill names         | Skills that should be reviewed when this artifact changes. |
+| `related-issues`    | list of GitHub issue URLs   | GitHub issues that motivated or track this artifact.       |
+| `related-artifacts` | list of repo-relative paths | Other files strongly coupled to this artifact.             |
+
 Add new markers only when there is a concrete recurring maintenance problem that the current marker set cannot represent.
 
 ## Marker Format
@@ -83,6 +91,8 @@ Recommended shape:
 semantic-links:
   skill-links:
     - <skill-name>
+  related-issues:
+    - https://github.com/torrust/torrust-bittorrent/issues/<number>
   related-artifacts:
     - <repo-relative-path>
 ---

--- a/examples/get_metadata/Cargo.toml
+++ b/examples/get_metadata/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 publish.workspace = true
 repository.workspace = true
 rust-version.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/examples/get_metadata/Cargo.toml
+++ b/examples/get_metadata/Cargo.toml
@@ -18,11 +18,11 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-dht = { path = "../../packages/dht" }
-handshake = { path = "../../packages/handshake" }
-metainfo = { path = "../../packages/metainfo" }
-peer = { path = "../../packages/peer" }
-select = { path = "../../packages/select" }
+torrust-dht = { path = "../../packages/dht" }
+torrust-handshake = { path = "../../packages/handshake" }
+torrust-metainfo = { path = "../../packages/metainfo" }
+torrust-peer = { path = "../../packages/peer" }
+torrust-select = { path = "../../packages/select" }
 
 clap = "4"
 futures = "0"

--- a/examples/get_metadata/src/main.rs
+++ b/examples/get_metadata/src/main.rs
@@ -4,26 +4,26 @@ use std::sync::{Arc, Once};
 use std::time::Duration;
 
 use clap::{Arg, ArgMatches, Command};
-use dht::handshaker_trait::HandshakerTrait;
-use dht::{DhtBuilder, DhtEvent, Router};
 use futures::future::{BoxFuture, Either};
 use futures::{FutureExt, Sink, SinkExt as _, StreamExt};
-use handshake::transports::TcpTransport;
-use handshake::{
-    DiscoveryInfo, Extension, Extensions, HandshakerBuilder, HandshakerConfig, InfoHash, InitiateMessage, PeerId, Protocol,
-};
 use hex::FromHex;
-use metainfo::Metainfo;
-use peer::messages::builders::ExtendedMessageBuilder;
-use peer::messages::{BitsExtensionMessage, PeerExtensionProtocolMessage, PeerWireProtocolMessage};
-use peer::protocols::{NullProtocol, PeerExtensionProtocol, PeerWireProtocol};
-use peer::{
-    PeerInfo, PeerManagerBuilder, PeerManagerInputMessage, PeerManagerOutputError, PeerManagerOutputMessage, PeerProtocolCodec,
-};
-use select::discovery::{IDiscoveryMessage, ODiscoveryMessage, UtMetadataModule};
-use select::{ControlMessage, IExtendedMessage, IUberMessage, OUberMessage, UberModuleBuilder};
 use tokio::signal;
 use tokio_util::codec::Framed;
+use torrust_dht::handshaker_trait::HandshakerTrait;
+use torrust_dht::{DhtBuilder, DhtEvent, Router};
+use torrust_handshake::transports::TcpTransport;
+use torrust_handshake::{
+    DiscoveryInfo, Extension, Extensions, HandshakerBuilder, HandshakerConfig, InfoHash, InitiateMessage, PeerId, Protocol,
+};
+use torrust_metainfo::Metainfo;
+use torrust_peer::messages::builders::ExtendedMessageBuilder;
+use torrust_peer::messages::{BitsExtensionMessage, PeerExtensionProtocolMessage, PeerWireProtocolMessage};
+use torrust_peer::protocols::{NullProtocol, PeerExtensionProtocol, PeerWireProtocol};
+use torrust_peer::{
+    PeerInfo, PeerManagerBuilder, PeerManagerInputMessage, PeerManagerOutputError, PeerManagerOutputMessage, PeerProtocolCodec,
+};
+use torrust_select::discovery::{IDiscoveryMessage, ODiscoveryMessage, UtMetadataModule};
+use torrust_select::{ControlMessage, IExtendedMessage, IUberMessage, OUberMessage, UberModuleBuilder};
 use tracing::level_filters::LevelFilter;
 
 pub static INIT: Once = Once::new();
@@ -123,7 +123,7 @@ async fn ctrl_c() {
 }
 
 enum SendUber {
-    Finished(Result<(), select::error::Error>),
+    Finished(Result<(), torrust_select::error::Error>),
     Interrupted,
 }
 

--- a/examples/simple_torrent/Cargo.toml
+++ b/examples/simple_torrent/Cargo.toml
@@ -19,10 +19,10 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-disk = { path = "../../packages/disk" }
-handshake = { path = "../../packages/handshake" }
-metainfo = { path = "../../packages/metainfo" }
-peer = { path = "../../packages/peer" }
+torrust-disk = { path = "../../packages/disk" }
+torrust-handshake = { path = "../../packages/handshake" }
+torrust-metainfo = { path = "../../packages/metainfo" }
+torrust-peer = { path = "../../packages/peer" }
 
 clap = "4"
 futures = "0"

--- a/examples/simple_torrent/Cargo.toml
+++ b/examples/simple_torrent/Cargo.toml
@@ -13,7 +13,7 @@ publish.workspace = true
 rust-version.workspace = true
 
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/examples/simple_torrent/src/main.rs
+++ b/examples/simple_torrent/src/main.rs
@@ -2,32 +2,32 @@ use std::collections::HashMap;
 use std::io::Read as _;
 use std::sync::{Arc, Once};
 
-use disk::fs::NativeFileSystem;
-use disk::fs_cache::FileHandleCache;
-use disk::{
-    Block, BlockMetadata, BlockMut, DiskManager, DiskManagerBuilder, DiskManagerSink, DiskManagerStream, IDiskMessage, InfoHash,
-    ODiskMessage,
-};
 use futures::channel::mpsc;
 use futures::future::Either;
 use futures::lock::Mutex;
 use futures::{SinkExt as _, StreamExt as _, stream};
-use handshake::transports::TcpTransport;
-use handshake::{
-    Extensions, Handshaker, HandshakerBuilder, HandshakerConfig, HandshakerStream, InitiateMessage, PeerId, Protocol,
-};
-use metainfo::{Info, Metainfo};
-use peer::messages::{BitFieldMessage, HaveMessage, PeerWireProtocolMessage, PieceMessage, RequestMessage};
-use peer::protocols::{NullProtocol, PeerWireProtocol};
-use peer::{
-    PeerInfo, PeerManagerBuilder, PeerManagerInputMessage, PeerManagerOutputError, PeerManagerOutputMessage, PeerManagerSink,
-    PeerManagerStream, PeerProtocolCodec,
-};
 use tokio::net::TcpStream;
 use tokio::signal;
 use tokio::task::JoinSet;
 use tokio_util::bytes::BytesMut;
 use tokio_util::codec::{Decoder, Framed};
+use torrust_disk::fs::NativeFileSystem;
+use torrust_disk::fs_cache::FileHandleCache;
+use torrust_disk::{
+    Block, BlockMetadata, BlockMut, DiskManager, DiskManagerBuilder, DiskManagerSink, DiskManagerStream, IDiskMessage, InfoHash,
+    ODiskMessage,
+};
+use torrust_handshake::transports::TcpTransport;
+use torrust_handshake::{
+    Extensions, Handshaker, HandshakerBuilder, HandshakerConfig, HandshakerStream, InitiateMessage, PeerId, Protocol,
+};
+use torrust_metainfo::{Info, Metainfo};
+use torrust_peer::messages::{BitFieldMessage, HaveMessage, PeerWireProtocolMessage, PieceMessage, RequestMessage};
+use torrust_peer::protocols::{NullProtocol, PeerWireProtocol};
+use torrust_peer::{
+    PeerInfo, PeerManagerBuilder, PeerManagerInputMessage, PeerManagerOutputError, PeerManagerOutputMessage, PeerManagerSink,
+    PeerManagerStream, PeerProtocolCodec,
+};
 use tracing::level_filters::LevelFilter;
 
 // Maximum number of requests that can be in flight at once.
@@ -320,7 +320,7 @@ async fn setup_handshaker() -> (TcpHandshaker, JoinSet<()>) {
         .unwrap()
 }
 
-type PeerManager = peer::PeerManager<
+type PeerManager = torrust_peer::PeerManager<
     Framed<TcpStream, PeerProtocolCodec<PeerWireProtocol<NullProtocol>>>,
     PeerWireProtocolMessage<NullProtocol>,
 >;
@@ -633,7 +633,7 @@ fn generate_piece_requests(info: &Info, block_size: usize) -> Vec<RequestMessage
 
     // Grab our piece length, and the sum of the lengths of each file in the torrent
     let piece_length: u64 = info.piece_length();
-    let mut total_file_length: u64 = info.files().map(metainfo::File::length).sum();
+    let mut total_file_length: u64 = info.files().map(torrust_metainfo::File::length).sum();
 
     // Loop over each piece (keep subtracting total file length by piece size, use cmp::min to handle last, smaller piece)
     let mut piece_index: u64 = 0;

--- a/packages/bencode/Cargo.toml
+++ b/packages/bencode/Cargo.toml
@@ -10,11 +10,11 @@ documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = false                # override with publish = true when ready for a public release
 rust-version.workspace = true
 
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/packages/bencode/Cargo.toml
+++ b/packages/bencode/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Efficient decoding and encoding for bencode."
 keywords = [ "bencode" ]
-name = "bencode"
+name = "torrust-bencode"
 readme = "README.md"
 
 authors.workspace = true

--- a/packages/bencode/benches/bencode_benchmark.rs
+++ b/packages/bencode/benches/bencode_benchmark.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
-use bencode::{BDecodeOpt, BencodeRef};
 use criterion::{Criterion, criterion_group, criterion_main};
+use torrust_bencode::{BDecodeOpt, BencodeRef};
 
 const B_NESTED_LISTS: &[u8; 100] =
     b"lllllllllllllllllllllllllllllllllllllllllllllllllleeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"; // cspell:disable-line

--- a/packages/bencode/src/lib.rs
+++ b/packages/bencode/src/lib.rs
@@ -5,8 +5,6 @@
 //! Decoding bencoded data:
 //!
 //! ```rust
-//!     extern crate bencode;
-//!
 //!     use torrust_bencode::{BencodeRef, BRefAccess, BDecodeOpt};
 //!
 //!     fn main() {
@@ -21,8 +19,7 @@
 //! Encoding bencoded data:
 //!
 //! ```rust
-//!     #[macro_use]
-//!     extern crate bencode;
+//!     use torrust_bencode::{ben_map, ben_int, ben_bytes};
 //!
 //!     fn main() {
 //!         let message = (ben_map!{

--- a/packages/bencode/src/lib.rs
+++ b/packages/bencode/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```rust
 //!     extern crate bencode;
 //!
-//!     use bencode::{BencodeRef, BRefAccess, BDecodeOpt};
+//!     use torrust_bencode::{BencodeRef, BRefAccess, BDecodeOpt};
 //!
 //!     fn main() {
 //!         let data = b"d12:lucky_numberi7ee"; // cspell:disable-line

--- a/packages/bencode/tests/mod.rs
+++ b/packages/bencode/tests/mod.rs
@@ -1,4 +1,4 @@
-use bencode::{ben_bytes, ben_int, ben_list, ben_map};
+use torrust_bencode::{ben_bytes, ben_int, ben_list, ben_map};
 
 #[test]
 fn positive_ben_map_macro() {

--- a/packages/dht/Cargo.toml
+++ b/packages/dht/Cargo.toml
@@ -10,11 +10,11 @@ documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = false                # override with publish = true when ready for a public release
 rust-version.workspace = true
 
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/packages/dht/Cargo.toml
+++ b/packages/dht/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Implementation of the bittorrent mainline DHT"
 keywords = [ "bittorrent", "dht", "distributed", "hash", "mainline" ]
-name = "dht"
+name = "torrust-dht"
 readme = "README.md"
 
 authors.workspace = true
@@ -20,9 +20,9 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-bencode = { path = "../bencode" }
-handshake = { path = "../handshake" }
-util = { path = "../util" }
+torrust-bencode = { path = "../bencode" }
+torrust-handshake = { path = "../handshake" }
+torrust-util = { path = "../util" }
 
 chrono = "0"
 crc = "3"

--- a/packages/dht/examples/debug.rs
+++ b/packages/dht/examples/debug.rs
@@ -3,13 +3,13 @@ use std::io::Read as _;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::sync::Once;
 
-use dht::handshaker_trait::HandshakerTrait;
-use dht::{DhtBuilder, Router};
 use futures::StreamExt;
 use futures::future::BoxFuture;
 use tokio::task::JoinSet;
+use torrust_dht::handshaker_trait::HandshakerTrait;
+use torrust_dht::{DhtBuilder, Router};
+use torrust_util::bt::{InfoHash, PeerId};
 use tracing::level_filters::LevelFilter;
-use util::bt::{InfoHash, PeerId};
 
 static INIT: Once = Once::new();
 

--- a/packages/dht/src/builder.rs
+++ b/packages/dht/src/builder.rs
@@ -6,8 +6,8 @@ use futures::SinkExt as _;
 use futures::channel::mpsc;
 use tokio::net::UdpSocket;
 use tokio::task::JoinSet;
-use util::bt::InfoHash;
-use util::net;
+use torrust_util::bt::InfoHash;
+use torrust_util::net;
 
 use crate::handshaker_trait::HandshakerTrait;
 use crate::router::Router;

--- a/packages/dht/src/error.rs
+++ b/packages/dht/src/error.rs
@@ -1,5 +1,5 @@
-use bencode::BencodeConvertError;
 use thiserror::Error;
+use torrust_bencode::BencodeConvertError;
 
 use crate::message::error::ErrorMessage;
 

--- a/packages/dht/src/handshaker_trait.rs
+++ b/packages/dht/src/handshaker_trait.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use futures::future::BoxFuture;
-use util::bt::{InfoHash, PeerId};
+use torrust_util::bt::{InfoHash, PeerId};
 
 /// Trait for peer discovery services to forward peer contact information and metadata.
 pub trait HandshakerTrait: Send {

--- a/packages/dht/src/lib.rs
+++ b/packages/dht/src/lib.rs
@@ -26,9 +26,9 @@ mod token;
 mod transaction;
 mod worker;
 
-pub use handshake::Handshaker;
+pub use torrust_handshake::Handshaker;
 /// Test
-pub use util::bt::{InfoHash, PeerId};
+pub use torrust_util::bt::{InfoHash, PeerId};
 
 pub use crate::builder::{DhtBuilder, MainlineDht};
 pub use crate::router::Router;

--- a/packages/dht/src/message/announce_peer.rs
+++ b/packages/dht/src/message/announce_peer.rs
@@ -1,8 +1,8 @@
 // TODO: Remove this when announces are implemented
 #![allow(unused)]
 
-use bencode::{BConvert, BDictAccess, BRefAccess, ben_bytes, ben_int, ben_map};
-use util::bt::{InfoHash, NodeId};
+use torrust_bencode::{BConvert, BDictAccess, BRefAccess, ben_bytes, ben_int, ben_map};
+use torrust_util::bt::{InfoHash, NodeId};
 
 use crate::error::DhtError;
 use crate::message;
@@ -63,7 +63,10 @@ impl<'a> AnnouncePeerRequest<'a> {
 
         // Technically, the specification says that the value is either 0 or 1 but goes on to say that
         // if it is not zero, then the source port should be used. We will allow values other than 0 or 1.
-        let response_port = match rqst_root.lookup(IMPLIED_PORT_KEY.as_bytes()).map(bencode::BRefAccess::int) {
+        let response_port = match rqst_root
+            .lookup(IMPLIED_PORT_KEY.as_bytes())
+            .map(torrust_bencode::BRefAccess::int)
+        {
             Some(Some(n)) if n != 0 => ConnectPort::Implied,
             _ => {
                 // If we hit this, the port either was not provided or it was of the wrong bencode type

--- a/packages/dht/src/message/compact_info.rs
+++ b/packages/dht/src/message/compact_info.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 use std::hash::Hash;
 use std::net::{Ipv4Addr, SocketAddrV4};
 
-use bencode::{BListAccess, BRefAccess};
-use util::bt::{self, NodeId};
-use util::error::{Error, LengthErrorKind, LengthResult};
-use util::sha::ShaHash;
+use torrust_bencode::{BListAccess, BRefAccess};
+use torrust_util::bt::{self, NodeId};
+use torrust_util::error::{Error, LengthErrorKind, LengthResult};
+use torrust_util::sha::ShaHash;
 
 // TODO: Update this module to accept data sources as both a slice of bytes and probably
 // a wrapper around a closest nodes iterator. Eventually when the interfaces are updated
@@ -206,9 +206,9 @@ fn socket_v4_from_bytes_be(bytes: &[u8]) -> LengthResult<SocketAddrV4> {
 mod tests {
     use std::net::{Ipv4Addr, SocketAddrV4};
 
-    use bencode::{BRefAccess, BencodeMut, BencodeRef, ben_bytes, ben_list};
-    use util::bt::NodeId;
-    use util::sha::ShaHash;
+    use torrust_bencode::{BRefAccess, BencodeMut, BencodeRef, ben_bytes, ben_list};
+    use torrust_util::bt::NodeId;
+    use torrust_util::sha::ShaHash;
 
     use crate::message::compact_info::{CompactNodeInfo, CompactValueInfo};
 

--- a/packages/dht/src/message/error.rs
+++ b/packages/dht/src/message/error.rs
@@ -3,8 +3,10 @@
 
 use std::borrow::Cow;
 
-use bencode::ext::BConvertExt;
-use bencode::{BConvert, BDictAccess, BListAccess, BRefAccess, BencodeConvertError, ben_bytes, ben_int, ben_list, ben_map};
+use torrust_bencode::ext::BConvertExt;
+use torrust_bencode::{
+    BConvert, BDictAccess, BListAccess, BRefAccess, BencodeConvertError, ben_bytes, ben_int, ben_list, ben_map,
+};
 
 use crate::error::DhtError;
 use crate::message;

--- a/packages/dht/src/message/find_node.rs
+++ b/packages/dht/src/message/find_node.rs
@@ -1,5 +1,5 @@
-use bencode::{BConvert, BDictAccess, BRefAccess, ben_bytes, ben_map};
-use util::bt::NodeId;
+use torrust_bencode::{BConvert, BDictAccess, BRefAccess, ben_bytes, ben_map};
+use torrust_util::bt::NodeId;
 
 use crate::error::DhtError;
 use crate::message;

--- a/packages/dht/src/message/get_data.rs
+++ b/packages/dht/src/message/get_data.rs
@@ -1,4 +1,4 @@
-use bencode::{Bencode, BencodeConvert, Dictionary};
+use torrust_bencode::{Bencode, BencodeConvert, Dictionary};
 
 use crate::error::{DhtError, DhtErrorKind, DhtResult};
 

--- a/packages/dht/src/message/get_peers.rs
+++ b/packages/dht/src/message/get_peers.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 use std::ops::Deref;
 
-use bencode::inner::BCowConvert;
-use bencode::{BConvert, BDictAccess, BMutAccess, BRefAccess, BencodeMut, ben_bytes, ben_map};
-use util::bt::{InfoHash, NodeId};
+use torrust_bencode::inner::BCowConvert;
+use torrust_bencode::{BConvert, BDictAccess, BMutAccess, BRefAccess, BencodeMut, ben_bytes, ben_map};
+use torrust_util::bt::{InfoHash, NodeId};
 
 use crate::error::DhtError;
 use crate::message;

--- a/packages/dht/src/message/mod.rs
+++ b/packages/dht/src/message/mod.rs
@@ -1,5 +1,5 @@
-use bencode::ext::BConvertExt;
-use bencode::{BConvert, BRefAccess, BencodeConvertError};
+use torrust_bencode::ext::BConvertExt;
+use torrust_bencode::{BConvert, BRefAccess, BencodeConvertError};
 
 use crate::error::DhtError;
 use crate::message::error::ErrorMessage;

--- a/packages/dht/src/message/ping.rs
+++ b/packages/dht/src/message/ping.rs
@@ -1,8 +1,8 @@
 // We don't really use PingRequests for our current algorithms, but that may change in the future!
 #![allow(unused)]
 
-use bencode::{BConvert, BDictAccess, BRefAccess, ben_bytes, ben_map};
-use util::bt::NodeId;
+use torrust_bencode::{BConvert, BDictAccess, BRefAccess, ben_bytes, ben_map};
+use torrust_util::bt::NodeId;
 
 use crate::error::DhtError;
 use crate::message;

--- a/packages/dht/src/message/put_data.rs
+++ b/packages/dht/src/message/put_data.rs
@@ -1,4 +1,4 @@
-use bencode::{Bencode, BencodeConvert, Dictionary};
+use torrust_bencode::{Bencode, BencodeConvert, Dictionary};
 
 use crate::error::{DhtError, DhtErrorKind, DhtResult};
 

--- a/packages/dht/src/message/request.rs
+++ b/packages/dht/src/message/request.rs
@@ -1,6 +1,6 @@
-use bencode::ext::BConvertExt;
-use bencode::{BConvert, BDictAccess, BRefAccess, BencodeConvertError};
-use util::bt::{InfoHash, NodeId};
+use torrust_bencode::ext::BConvertExt;
+use torrust_bencode::{BConvert, BDictAccess, BRefAccess, BencodeConvertError};
+use torrust_util::bt::{InfoHash, NodeId};
 
 use crate::error::DhtError;
 use crate::message;

--- a/packages/dht/src/message/response.rs
+++ b/packages/dht/src/message/response.rs
@@ -1,6 +1,6 @@
-use bencode::ext::BConvertExt;
-use bencode::{BConvert, BDictAccess, BListAccess, BRefAccess, BencodeConvertError};
-use util::bt::NodeId;
+use torrust_bencode::ext::BConvertExt;
+use torrust_bencode::{BConvert, BDictAccess, BListAccess, BRefAccess, BencodeConvertError};
+use torrust_util::bt::NodeId;
 
 use crate::error::DhtError;
 use crate::message::announce_peer::AnnouncePeerResponse;

--- a/packages/dht/src/routing/bucket.rs
+++ b/packages/dht/src/routing/bucket.rs
@@ -5,7 +5,7 @@ use std::iter::Filter;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::slice::Iter;
 
-use util::bt::{self, NodeId};
+use torrust_util::bt::{self, NodeId};
 
 use crate::routing::node::{Node, NodeStatus};
 
@@ -157,8 +157,8 @@ impl<'a> Iterator for PingableNodes<'a> {
 
 #[cfg(test)]
 mod tests {
-    use util::sha::{self, ShaHash};
-    use util::test as bip_test;
+    use torrust_util::sha::{self, ShaHash};
+    use torrust_util::test as bip_test;
 
     use crate::routing::bucket::{self, Bucket};
     use crate::routing::node::{Node, NodeStatus};

--- a/packages/dht/src/routing/node.rs
+++ b/packages/dht/src/routing/node.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use chrono::{DateTime, Duration, Utc};
-use util::bt::NodeId;
-use util::test;
+use torrust_util::bt::NodeId;
+use torrust_util::test;
 
 // TODO: Should remove as_* functions and replace them with from_requested, from_responded, etc to hide the logic
 // of the nodes initial status.
@@ -260,8 +260,8 @@ mod tests {
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
     use chrono::Duration;
-    use util::bt::NodeId;
-    use util::test as bip_test;
+    use torrust_util::bt::NodeId;
+    use torrust_util::test as bip_test;
 
     use crate::routing::node::{Node, NodeStatus};
 

--- a/packages/dht/src/routing/table.rs
+++ b/packages/dht/src/routing/table.rs
@@ -2,8 +2,8 @@ use std::iter::Filter;
 use std::slice::Iter;
 
 use rand;
-use util::bt::NodeId;
-use util::sha::{self, ShaHash, XorRep};
+use torrust_util::bt::NodeId;
+use torrust_util::sha::{self, ShaHash, XorRep};
 
 use crate::routing::bucket::{self, Bucket};
 use crate::routing::node::{Node, NodeStatus};
@@ -433,8 +433,8 @@ const fn index_is_in_bounds(length: usize, checked_index: Option<usize>) -> bool
 
 #[cfg(test)]
 mod tests {
-    use util::bt::{self, NodeId};
-    use util::test as bip_test;
+    use torrust_util::bt::{self, NodeId};
+    use torrust_util::test as bip_test;
 
     use crate::routing::bucket;
     use crate::routing::node::Node;

--- a/packages/dht/src/security.rs
+++ b/packages/dht/src/security.rs
@@ -4,8 +4,8 @@
 use std::net::Ipv4Addr;
 
 use crc::{CRC_32_ISCSI, Crc};
-use util::bt::{self, NodeId};
-use util::convert;
+use torrust_util::bt::{self, NodeId};
+use torrust_util::convert;
 
 const IPV4_MASK: u32 = 0x030F_3FFF;
 const IPV6_MASK: u64 = 0x0103_070F_1F3F_7FFF;

--- a/packages/dht/src/storage.rs
+++ b/packages/dht/src/storage.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::Entry;
 use std::net::SocketAddr;
 
 use chrono::{DateTime, Duration, Utc};
-use util::bt::InfoHash;
+use torrust_util::bt::InfoHash;
 
 const MAX_ITEMS_STORED: usize = 500;
 
@@ -197,7 +197,7 @@ impl Eq for ItemExpiration {}
 #[cfg(test)]
 mod tests {
     use chrono::Duration;
-    use util::{bt, test as bip_test};
+    use torrust_util::{bt, test as bip_test};
 
     use crate::storage::{self, AnnounceStorage};
 

--- a/packages/dht/src/token.rs
+++ b/packages/dht/src/token.rs
@@ -1,10 +1,10 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use chrono::{DateTime, Duration, Utc};
-use util::convert;
-use util::error::{Error, LengthErrorKind, LengthResult};
-use util::net::IpAddr;
-use util::sha::{self, ShaHash};
+use torrust_util::convert;
+use torrust_util::error::{Error, LengthErrorKind, LengthResult};
+use torrust_util::net::IpAddr;
+use torrust_util::sha::{self, ShaHash};
 
 /// We will partially follow the bittorrent implementation for issuing tokens to nodes, the
 /// secret will change every 10 minutes and tokens up to 10 minutes old will be accepted. This
@@ -196,7 +196,7 @@ fn validate_token_from_addr_v6(v6_addr: Ipv6Addr, token: Token, secret: u32) -> 
 #[cfg(test)]
 mod tests {
     use chrono::Duration;
-    use util::test as bip_test;
+    use torrust_util::test as bip_test;
 
     use crate::token::TokenStore;
 

--- a/packages/dht/src/transaction.rs
+++ b/packages/dht/src/transaction.rs
@@ -1,4 +1,4 @@
-use util::convert;
+use torrust_util::convert;
 
 // Transaction IDs are going to be vital for both scalability and performance concerns.
 // They allow us to both protect against unsolicited responses as well as dropping those
@@ -69,7 +69,7 @@ impl AIDGenerator {
         let (next_alloc, mut action_ids) = generate_aids(0);
 
         // Randomize the order of ids
-        util::fisher_shuffle(&mut action_ids);
+        torrust_util::fisher_shuffle(&mut action_ids);
 
         Self {
             next_alloc,
@@ -91,7 +91,7 @@ impl AIDGenerator {
             let (next_alloc, mut action_ids) = generate_aids(self.next_alloc);
 
             // Randomize the order of ids
-            util::fisher_shuffle(&mut action_ids);
+            torrust_util::fisher_shuffle(&mut action_ids);
 
             self.next_alloc = next_alloc;
             self.action_ids = action_ids;
@@ -158,7 +158,7 @@ impl MIDGenerator {
             let (next_alloc, mut message_ids) = generate_mids(self.next_alloc);
 
             // Randomize the order of ids
-            util::fisher_shuffle(&mut message_ids);
+            torrust_util::fisher_shuffle(&mut message_ids);
 
             self.next_alloc = next_alloc;
             self.message_ids = message_ids;

--- a/packages/dht/src/worker/bootstrap.rs
+++ b/packages/dht/src/worker/bootstrap.rs
@@ -10,7 +10,7 @@ use futures::future::BoxFuture;
 use futures::{FutureExt as _, SinkExt as _};
 use tokio::task::JoinSet;
 use tokio::time::{Duration, sleep};
-use util::bt::{self, NodeId};
+use torrust_util::bt::{self, NodeId};
 
 use crate::handshaker_trait::HandshakerTrait;
 use crate::message::find_node::FindNodeRequest;

--- a/packages/dht/src/worker/handler.rs
+++ b/packages/dht/src/worker/handler.rs
@@ -4,15 +4,15 @@ use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
-use bencode::{BDecodeOpt, BencodeMut, BencodeRef, ben_bytes};
 use futures::channel::mpsc;
 use futures::future::BoxFuture;
 use futures::{FutureExt, SinkExt, StreamExt as _};
 use tokio::net::UdpSocket;
 use tokio::task::JoinSet;
-use util::bt::InfoHash;
-use util::convert;
-use util::net::IpAddr;
+use torrust_bencode::{BDecodeOpt, BencodeMut, BencodeRef, ben_bytes};
+use torrust_util::bt::InfoHash;
+use torrust_util::convert;
+use torrust_util::net::IpAddr;
 
 use crate::handshaker_trait::HandshakerTrait;
 use crate::message::MessageType;

--- a/packages/dht/src/worker/lookup.rs
+++ b/packages/dht/src/worker/lookup.rs
@@ -3,16 +3,16 @@ use std::net::{SocketAddr, SocketAddrV4};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
-use bencode::BRefAccess;
 use futures::channel::mpsc;
 use futures::channel::mpsc::SendError;
 use futures::future::BoxFuture;
 use futures::{FutureExt, SinkExt as _};
 use tokio::task::JoinSet;
 use tokio::time::{Duration, Instant, sleep};
-use util::bt::{self, InfoHash, NodeId};
-use util::net;
-use util::sha::ShaHash;
+use torrust_bencode::BRefAccess;
+use torrust_util::bt::{self, InfoHash, NodeId};
+use torrust_util::net;
+use torrust_util::sha::ShaHash;
 
 use crate::message::announce_peer::{AnnouncePeerRequest, ConnectPort};
 use crate::message::get_peers::{CompactInfoType, GetPeersRequest, GetPeersResponse};

--- a/packages/dht/src/worker/mod.rs
+++ b/packages/dht/src/worker/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use futures::channel::mpsc;
 use tokio::net::UdpSocket;
 use tokio::task::JoinSet;
-use util::bt::InfoHash;
+use torrust_util::bt::InfoHash;
 
 use crate::handshaker_trait::HandshakerTrait;
 use crate::router::Router;

--- a/packages/dht/src/worker/refresh.rs
+++ b/packages/dht/src/worker/refresh.rs
@@ -6,7 +6,7 @@ use futures::SinkExt as _;
 use futures::channel::mpsc::{self, SendError};
 use tokio::task::JoinSet;
 use tokio::time::{Duration, sleep};
-use util::bt::{self, NodeId};
+use torrust_util::bt::{self, NodeId};
 
 use crate::message::find_node::FindNodeRequest;
 use crate::routing::node::NodeStatus;

--- a/packages/disk/Cargo.toml
+++ b/packages/disk/Cargo.toml
@@ -10,11 +10,11 @@ documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = false                # override with publish = true when ready for a public release
 rust-version.workspace = true
 
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/packages/disk/Cargo.toml
+++ b/packages/disk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Torrust BitTorrent Disk Module"
 keywords = [ "disk", "filesystem", "fs" ]
-name = "disk"
+name = "torrust-disk"
 readme = "README.md"
 
 authors.workspace = true
@@ -20,8 +20,8 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-metainfo = { path = "../metainfo" }
-util = { path = "../util" }
+torrust-metainfo = { path = "../metainfo" }
+torrust-util = { path = "../util" }
 
 bytes = "1"
 crossbeam = "0"

--- a/packages/disk/benches/disk_benchmark.rs
+++ b/packages/disk/benches/disk_benchmark.rs
@@ -4,14 +4,14 @@ use std::sync::Arc;
 
 use bytes::BytesMut;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use disk::error::TorrentError;
-use disk::fs::NativeFileSystem;
-use disk::fs_cache::FileHandleCache;
-use disk::{Block, BlockMetadata, DiskManagerBuilder, FileSystem, IDiskMessage, InfoHash, ODiskMessage};
 use futures::{SinkExt, StreamExt};
-use metainfo::{DirectAccessor, Metainfo, MetainfoBuilder, PieceLength};
 use rand::RngExt;
 use tokio::sync::Mutex;
+use torrust_disk::error::TorrentError;
+use torrust_disk::fs::NativeFileSystem;
+use torrust_disk::fs_cache::FileHandleCache;
+use torrust_disk::{Block, BlockMetadata, DiskManagerBuilder, FileSystem, IDiskMessage, InfoHash, ODiskMessage};
+use torrust_metainfo::{DirectAccessor, Metainfo, MetainfoBuilder, PieceLength};
 
 /// Set to true if you are playing around with anything that could affect file
 /// sizes for an existing or new benchmarks. As a precaution, if the disk manager

--- a/packages/disk/examples/add_torrent.rs
+++ b/packages/disk/examples/add_torrent.rs
@@ -3,10 +3,10 @@
 use std::io::{BufRead, Read as _, Write as _};
 use std::sync::{Arc, Once};
 
-use disk::fs::NativeFileSystem;
-use disk::{DiskManagerBuilder, IDiskMessage, ODiskMessage};
 use futures::{SinkExt, StreamExt};
-use metainfo::Metainfo;
+use torrust_disk::fs::NativeFileSystem;
+use torrust_disk::{DiskManagerBuilder, IDiskMessage, ODiskMessage};
+use torrust_metainfo::Metainfo;
 use tracing::level_filters::LevelFilter;
 
 static INIT: Once = Once::new();

--- a/packages/disk/src/disk/mod.rs
+++ b/packages/disk/src/disk/mod.rs
@@ -1,5 +1,5 @@
-use metainfo::Metainfo;
-use util::bt::InfoHash;
+use torrust_metainfo::Metainfo;
+use torrust_util::bt::InfoHash;
 
 use crate::error::{BlockError, TorrentError};
 use crate::memory::block::{Block, BlockMut};

--- a/packages/disk/src/disk/tasks/context.rs
+++ b/packages/disk/src/disk/tasks/context.rs
@@ -6,8 +6,8 @@ use futures::channel::mpsc;
 use futures::future::BoxFuture;
 use futures::lock::Mutex;
 use futures::sink::SinkExt;
-use metainfo::Metainfo;
-use util::bt::InfoHash;
+use torrust_metainfo::Metainfo;
+use torrust_util::bt::InfoHash;
 
 use crate::FileSystem;
 use crate::disk::ODiskMessage;

--- a/packages/disk/src/disk/tasks/helpers/mod.rs
+++ b/packages/disk/src/disk/tasks/helpers/mod.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use metainfo::File;
+use torrust_metainfo::File;
 
 pub mod piece_accessor;
 pub mod piece_checker;

--- a/packages/disk/src/disk/tasks/helpers/piece_checker.rs
+++ b/packages/disk/src/disk/tasks/helpers/piece_checker.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use futures::future::BoxFuture;
 use futures::lock::Mutex;
-use metainfo::{Info, Metainfo};
-use util::bt::InfoHash;
+use torrust_metainfo::{Info, Metainfo};
+use torrust_util::bt::InfoHash;
 
 use crate::disk::fs::FileSystem;
 use crate::disk::tasks::context::MetainfoState;
@@ -89,7 +89,7 @@ where
     /// the caller can use to skip (if the torrent was partially downloaded before).
     async fn fill_checker_state(&self) {
         let piece_length = self.state.file.info().piece_length();
-        let total_bytes: u64 = self.state.file.info().files().map(metainfo::File::length).sum();
+        let total_bytes: u64 = self.state.file.info().files().map(torrust_metainfo::File::length).sum();
 
         let full_pieces = total_bytes / piece_length;
         let last_piece_size = last_piece_size(self.state.file.info());
@@ -152,7 +152,7 @@ where
 
 fn last_piece_size(info_dict: &Info) -> usize {
     let piece_length = info_dict.piece_length();
-    let total_bytes: u64 = info_dict.files().map(metainfo::File::length).sum();
+    let total_bytes: u64 = info_dict.files().map(torrust_metainfo::File::length).sum();
 
     (total_bytes % piece_length).try_into().unwrap()
 }
@@ -332,7 +332,7 @@ fn merge_piece_messages(message_a: &BlockMetadata, message_b: &BlockMetadata) ->
 
 #[cfg(test)]
 mod tests {
-    use util::bt;
+    use torrust_util::bt;
 
     use crate::memory::block::BlockMetadata;
 

--- a/packages/disk/src/disk/tasks/mod.rs
+++ b/packages/disk/src/disk/tasks/mod.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use futures::channel::mpsc;
 use futures::lock::Mutex;
 use futures::{FutureExt, SinkExt as _};
-use metainfo::Metainfo;
-use util::bt::InfoHash;
+use torrust_metainfo::Metainfo;
+use torrust_util::bt::InfoHash;
 
 use crate::disk::fs::FileSystem;
 use crate::disk::tasks::context::DiskManagerContext;

--- a/packages/disk/src/error.rs
+++ b/packages/disk/src/error.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use thiserror::Error;
-use util::bt::InfoHash;
+use torrust_util::bt::InfoHash;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Error, Debug)]

--- a/packages/disk/src/lib.rs
+++ b/packages/disk/src/lib.rs
@@ -20,4 +20,4 @@ pub mod fs_cache {
     pub use crate::disk::fs::cache::file_handle::FileHandleCache;
 }
 
-pub use util::bt::InfoHash;
+pub use torrust_util::bt::InfoHash;

--- a/packages/disk/src/memory/block.rs
+++ b/packages/disk/src/memory/block.rs
@@ -1,7 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use bytes::{Bytes, BytesMut};
-use util::bt::{self, InfoHash};
+use torrust_util::bt::{self, InfoHash};
 
 //----------------------------------------------------------------------------//
 

--- a/packages/disk/tests/add_torrent.rs
+++ b/packages/disk/tests/add_torrent.rs
@@ -2,10 +2,10 @@ use common::{
     DEFAULT_TIMEOUT, INIT, InMemoryFileSystem, MultiFileDirectAccessor, random_buffer, runtime_loop_with_timeout,
     tracing_stderr_init,
 };
-use disk::{DiskManagerBuilder, FileSystem as _, IDiskMessage, ODiskMessage};
 use futures::future::{self, Either};
 use futures::{FutureExt, SinkExt as _};
-use metainfo::{Metainfo, MetainfoBuilder, PieceLength};
+use torrust_disk::{DiskManagerBuilder, FileSystem as _, IDiskMessage, ODiskMessage};
+use torrust_metainfo::{Metainfo, MetainfoBuilder, PieceLength};
 use tracing::level_filters::LevelFilter;
 
 mod common;

--- a/packages/disk/tests/common/mod.rs
+++ b/packages/disk/tests/common/mod.rs
@@ -4,14 +4,14 @@ use std::sync::{Arc, Mutex, Once, Weak};
 use std::time::Duration;
 
 use bytes::BytesMut;
-use disk::{BlockMetadata, BlockMut, FileSystem, IDiskMessage};
 use futures::future::BoxFuture;
 use futures::stream::Stream;
 use futures::{Sink, SinkExt as _, StreamExt as _, future};
-use metainfo::{Accessor, IntoAccessor, PieceAccess};
 use tokio::time::timeout;
+use torrust_disk::{BlockMetadata, BlockMut, FileSystem, IDiskMessage};
+use torrust_metainfo::{Accessor, IntoAccessor, PieceAccess};
+use torrust_util::bt::InfoHash;
 use tracing::level_filters::LevelFilter;
-use util::bt::InfoHash;
 
 #[allow(dead_code)]
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_millis(500);

--- a/packages/disk/tests/complete_torrent.rs
+++ b/packages/disk/tests/complete_torrent.rs
@@ -2,11 +2,11 @@ use common::{
     DEFAULT_TIMEOUT, INIT, InMemoryFileSystem, MultiFileDirectAccessor, random_buffer, runtime_loop_with_timeout, send_block,
     tracing_stderr_init,
 };
-use disk::{DiskManagerBuilder, IDiskMessage, ODiskMessage};
 use futures::future::{self, Either};
 use futures::{FutureExt, SinkExt as _};
-use metainfo::{Metainfo, MetainfoBuilder, PieceLength};
 use tokio::task::JoinSet;
+use torrust_disk::{DiskManagerBuilder, IDiskMessage, ODiskMessage};
+use torrust_metainfo::{Metainfo, MetainfoBuilder, PieceLength};
 use tracing::level_filters::LevelFilter;
 
 mod common;

--- a/packages/disk/tests/disk_manager_send_backpressure.rs
+++ b/packages/disk/tests/disk_manager_send_backpressure.rs
@@ -1,7 +1,7 @@
 use common::{DEFAULT_TIMEOUT, INIT, InMemoryFileSystem, MultiFileDirectAccessor, random_buffer, tracing_stderr_init};
-use disk::{DiskManagerBuilder, IDiskMessage};
 use futures::{FutureExt, SinkExt as _, StreamExt as _};
-use metainfo::{Metainfo, MetainfoBuilder, PieceLength};
+use torrust_disk::{DiskManagerBuilder, IDiskMessage};
+use torrust_metainfo::{Metainfo, MetainfoBuilder, PieceLength};
 use tracing::level_filters::LevelFilter;
 
 mod common;

--- a/packages/disk/tests/load_block.rs
+++ b/packages/disk/tests/load_block.rs
@@ -1,9 +1,9 @@
 use bytes::BytesMut;
 use common::{INIT, InMemoryFileSystem, MultiFileDirectAccessor, random_buffer, tracing_stderr_init};
-use disk::{Block, BlockMetadata, BlockMut, DiskManagerBuilder, IDiskMessage, ODiskMessage};
 use futures::{SinkExt as _, StreamExt as _};
-use metainfo::{Metainfo, MetainfoBuilder, PieceLength};
 use tokio::time::{Duration, timeout};
+use torrust_disk::{Block, BlockMetadata, BlockMut, DiskManagerBuilder, IDiskMessage, ODiskMessage};
+use torrust_metainfo::{Metainfo, MetainfoBuilder, PieceLength};
 use tracing::level_filters::LevelFilter;
 
 mod common;

--- a/packages/disk/tests/process_block.rs
+++ b/packages/disk/tests/process_block.rs
@@ -3,9 +3,9 @@ use common::{
     DEFAULT_TIMEOUT, INIT, InMemoryFileSystem, MultiFileDirectAccessor, random_buffer, runtime_loop_with_timeout,
     tracing_stderr_init,
 };
-use disk::{Block, BlockMetadata, DiskManagerBuilder, FileSystem, IDiskMessage, ODiskMessage};
 use futures::{FutureExt as _, SinkExt as _, future};
-use metainfo::{Metainfo, MetainfoBuilder, PieceLength};
+use torrust_disk::{Block, BlockMetadata, DiskManagerBuilder, FileSystem, IDiskMessage, ODiskMessage};
+use torrust_metainfo::{Metainfo, MetainfoBuilder, PieceLength};
 use tracing::level_filters::LevelFilter;
 
 mod common;

--- a/packages/disk/tests/remove_torrent.rs
+++ b/packages/disk/tests/remove_torrent.rs
@@ -3,9 +3,9 @@ use common::{
     DEFAULT_TIMEOUT, INIT, InMemoryFileSystem, MultiFileDirectAccessor, random_buffer, runtime_loop_with_timeout,
     tracing_stderr_init,
 };
-use disk::{Block, BlockMetadata, DiskManagerBuilder, IDiskMessage, ODiskMessage};
 use futures::{FutureExt, SinkExt as _, future};
-use metainfo::{Metainfo, MetainfoBuilder, PieceLength};
+use torrust_disk::{Block, BlockMetadata, DiskManagerBuilder, IDiskMessage, ODiskMessage};
+use torrust_metainfo::{Metainfo, MetainfoBuilder, PieceLength};
 use tracing::level_filters::LevelFilter;
 
 mod common;

--- a/packages/disk/tests/resume_torrent.rs
+++ b/packages/disk/tests/resume_torrent.rs
@@ -2,9 +2,9 @@ use common::{
     DEFAULT_TIMEOUT, INIT, InMemoryFileSystem, MultiFileDirectAccessor, random_buffer, runtime_loop_with_timeout, send_block,
     tracing_stderr_init,
 };
-use disk::{DiskManagerBuilder, IDiskMessage, ODiskMessage};
 use futures::{FutureExt, SinkExt as _, future};
-use metainfo::{Metainfo, MetainfoBuilder, PieceLength};
+use torrust_disk::{DiskManagerBuilder, IDiskMessage, ODiskMessage};
+use torrust_metainfo::{Metainfo, MetainfoBuilder, PieceLength};
 use tracing::level_filters::LevelFilter;
 
 mod common;

--- a/packages/handshake/Cargo.toml
+++ b/packages/handshake/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Common handshaking interface as well as a default handshake implementation"
 keywords = [ "bittorrent", "handshake" ]
-name = "handshake"
+name = "torrust-handshake"
 readme = "README.md"
 
 authors.workspace = true
@@ -20,7 +20,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-util = { path = "../util" }
+torrust-util = { path = "../util" }
 
 bytes = "1"
 futures = "0"

--- a/packages/handshake/Cargo.toml
+++ b/packages/handshake/Cargo.toml
@@ -10,11 +10,11 @@ documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = false                # override with publish = true when ready for a public release
 rust-version.workspace = true
 
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/packages/handshake/examples/handshake_torrent.rs
+++ b/packages/handshake/examples/handshake_torrent.rs
@@ -5,9 +5,9 @@ use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::Duration;
 
 use futures::SinkExt;
-use handshake::transports::TcpTransport;
-use handshake::{HandshakerBuilder, InitiateMessage, Protocol};
 use tokio::time::sleep;
+use torrust_handshake::transports::TcpTransport;
+use torrust_handshake::{HandshakerBuilder, InitiateMessage, Protocol};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {

--- a/packages/handshake/src/bittorrent/framed.rs
+++ b/packages/handshake/src/bittorrent/framed.rs
@@ -300,8 +300,8 @@ mod tests {
     use futures::SinkExt as _;
     use futures::stream::StreamExt;
     use tokio::io::{AsyncRead, AsyncReadExt as _, AsyncWriteExt as _};
+    use torrust_util::bt::{self, InfoHash, PeerId};
     use tracing::level_filters::LevelFilter;
-    use util::bt::{self, InfoHash, PeerId};
 
     use super::FramedHandshake;
     use crate::bittorrent::message::HandshakeMessage;

--- a/packages/handshake/src/bittorrent/message.rs
+++ b/packages/handshake/src/bittorrent/message.rs
@@ -2,7 +2,7 @@ use nom::bytes::complete::take;
 use nom::combinator::map_res;
 use nom::{IResult, Parser};
 use tokio::io::{AsyncWrite, AsyncWriteExt as _};
-use util::bt::{self, InfoHash, PeerId};
+use torrust_util::bt::{self, InfoHash, PeerId};
 
 use crate::message::extensions::{self, Extensions};
 use crate::message::protocol::Protocol;
@@ -105,7 +105,7 @@ fn parse_remote_pid(bytes: &[u8]) -> IResult<&[u8], PeerId> {
 mod tests {
     use std::io::Write as _;
 
-    use util::bt::{self, InfoHash, PeerId};
+    use torrust_util::bt::{self, InfoHash, PeerId};
 
     use super::HandshakeMessage;
     use crate::message::extensions::{self, Extensions};

--- a/packages/handshake/src/discovery.rs
+++ b/packages/handshake/src/discovery.rs
@@ -1,4 +1,4 @@
-use util::bt::PeerId;
+use torrust_util::bt::PeerId;
 
 /// Trait for advertisement information that other peers can discover.
 #[allow(clippy::module_name_repetitions)]

--- a/packages/handshake/src/filter/filters.rs
+++ b/packages/handshake/src/filter/filters.rs
@@ -104,7 +104,7 @@ pub mod test_filters {
     use std::any::Any;
     use std::net::SocketAddr;
 
-    use util::bt::PeerId;
+    use torrust_util::bt::PeerId;
 
     use crate::filter::{FilterDecision, HandshakeFilter};
     use crate::message::protocol::Protocol;

--- a/packages/handshake/src/filter/mod.rs
+++ b/packages/handshake/src/filter/mod.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 use std::net::SocketAddr;
 
-use util::bt::{InfoHash, PeerId};
+use torrust_util::bt::{InfoHash, PeerId};
 
 use crate::message::extensions::Extensions;
 use crate::message::protocol::Protocol;

--- a/packages/handshake/src/handshake/builder.rs
+++ b/packages/handshake/src/handshake/builder.rs
@@ -3,8 +3,8 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use rand::RngExt as _;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::task::JoinSet;
-use util::bt::PeerId;
-use util::convert;
+use torrust_util::bt::PeerId;
+use torrust_util::convert;
 
 use super::Handshaker;
 use crate::{Extensions, HandshakerConfig, Transport};

--- a/packages/handshake/src/handshake/handler/handshaker.rs
+++ b/packages/handshake/src/handshake/handler/handshaker.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use futures::future::BoxFuture;
 use futures::{FutureExt as _, SinkExt as _, StreamExt as _};
 use tokio::io::{AsyncRead, AsyncWrite};
-use util::bt::PeerId;
+use torrust_util::bt::PeerId;
 
 use crate::bittorrent::framed::FramedHandshake;
 use crate::bittorrent::message::HandshakeMessage;
@@ -139,7 +139,7 @@ mod tests {
 
     use std::time::Duration;
 
-    use util::bt::{self, InfoHash, PeerId};
+    use torrust_util::bt::{self, InfoHash, PeerId};
 
     use super::HandshakeMessage;
     use crate::filter::filters::Filters;

--- a/packages/handshake/src/handshake/handler/initiator.rs
+++ b/packages/handshake/src/handshake/handler/initiator.rs
@@ -45,7 +45,7 @@ where
 mod tests {
     use std::time::Duration;
 
-    use util::bt::{self, InfoHash, PeerId};
+    use torrust_util::bt::{self, InfoHash, PeerId};
 
     use crate::filter::filters::Filters;
     use crate::filter::filters::test_filters::{BlockAddrFilter, BlockPeerIdFilter, BlockProtocolFilter};

--- a/packages/handshake/src/handshake/handler/mod.rs
+++ b/packages/handshake/src/handshake/handler/mod.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 
 use futures::sink::SinkExt;
 use futures::stream::StreamExt;
-use util::bt::{InfoHash, PeerId};
+use torrust_util::bt::{InfoHash, PeerId};
 
 use crate::filter::FilterDecision;
 use crate::filter::filters::Filters;

--- a/packages/handshake/src/handshake/mod.rs
+++ b/packages/handshake/src/handshake/mod.rs
@@ -9,7 +9,7 @@ use sink::HandshakerSink;
 use stream::HandshakerStream;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::task::JoinSet;
-use util::bt::PeerId;
+use torrust_util::bt::PeerId;
 
 use crate::filter::filters::Filters;
 use crate::local_addr::LocalAddr as _;

--- a/packages/handshake/src/handshake/sink.rs
+++ b/packages/handshake/src/handshake/sink.rs
@@ -4,7 +4,7 @@ use futures::SinkExt as _;
 use futures::channel::mpsc;
 use futures::sink::Sink;
 use futures::task::{Context, Poll};
-use util::bt::PeerId;
+use torrust_util::bt::PeerId;
 
 use crate::discovery::DiscoveryInfo;
 use crate::filter::filters::Filters;

--- a/packages/handshake/src/lib.rs
+++ b/packages/handshake/src/lib.rs
@@ -25,4 +25,4 @@ pub mod transports {
     pub use crate::transport::{TcpListenerStream, TcpTransport};
 }
 
-pub use util::bt::{InfoHash, PeerId};
+pub use torrust_util::bt::{InfoHash, PeerId};

--- a/packages/handshake/src/message/complete.rs
+++ b/packages/handshake/src/message/complete.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use util::bt::{InfoHash, PeerId};
+use torrust_util::bt::{InfoHash, PeerId};
 
 use crate::message::extensions::Extensions;
 use crate::message::protocol::Protocol;

--- a/packages/handshake/src/message/initiate.rs
+++ b/packages/handshake/src/message/initiate.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use util::bt::InfoHash;
+use torrust_util::bt::InfoHash;
 
 use crate::message::protocol::Protocol;
 

--- a/packages/handshake/tests/test_byte_after_handshake.rs
+++ b/packages/handshake/tests/test_byte_after_handshake.rs
@@ -3,11 +3,11 @@ use std::net::TcpStream;
 
 use common::{INIT, tracing_stderr_init};
 use futures::stream::StreamExt;
-use handshake::transports::TcpTransport;
-use handshake::{DiscoveryInfo, HandshakerBuilder};
 use tokio::io::AsyncReadExt as _;
+use torrust_handshake::transports::TcpTransport;
+use torrust_handshake::{DiscoveryInfo, HandshakerBuilder};
+use torrust_util::bt::{self};
 use tracing::level_filters::LevelFilter;
-use util::bt::{self};
 
 mod common;
 

--- a/packages/handshake/tests/test_bytes_after_handshake.rs
+++ b/packages/handshake/tests/test_bytes_after_handshake.rs
@@ -3,11 +3,11 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
 
 use common::{INIT, tracing_stderr_init};
 use futures::stream::StreamExt;
-use handshake::transports::TcpTransport;
-use handshake::{DiscoveryInfo, HandshakerBuilder};
 use tokio::io::AsyncReadExt as _;
+use torrust_handshake::transports::TcpTransport;
+use torrust_handshake::{DiscoveryInfo, HandshakerBuilder};
+use torrust_util::bt::{self};
 use tracing::level_filters::LevelFilter;
-use util::bt::{self};
 
 mod common;
 

--- a/packages/handshake/tests/test_connect.rs
+++ b/packages/handshake/tests/test_connect.rs
@@ -2,11 +2,11 @@ use common::{INIT, tracing_stderr_init};
 use futures::future::try_join;
 use futures::sink::SinkExt;
 use futures::stream::StreamExt;
-use handshake::transports::TcpTransport;
-use handshake::{DiscoveryInfo, HandshakerBuilder, InitiateMessage, Protocol};
 use tokio::net::TcpStream;
+use torrust_handshake::transports::TcpTransport;
+use torrust_handshake::{DiscoveryInfo, HandshakerBuilder, InitiateMessage, Protocol};
+use torrust_util::bt::{self};
 use tracing::level_filters::LevelFilter;
-use util::bt::{self};
 
 mod common;
 
@@ -54,12 +54,12 @@ async fn positive_connect() {
             .unwrap();
 
         let handshaker_one_future = async {
-            let message: handshake::CompleteMessage<TcpStream> = handshaker_one.next().await.unwrap().unwrap();
+            let message: torrust_handshake::CompleteMessage<TcpStream> = handshaker_one.next().await.unwrap().unwrap();
             Ok::<_, ()>(message)
         };
 
         let handshaker_two_future = async {
-            let message: handshake::CompleteMessage<TcpStream> = handshaker_two.next().await.unwrap().unwrap();
+            let message: torrust_handshake::CompleteMessage<TcpStream> = handshaker_two.next().await.unwrap().unwrap();
             Ok::<_, ()>(message)
         };
 

--- a/packages/handshake/tests/test_filter_allow_all.rs
+++ b/packages/handshake/tests/test_filter_allow_all.rs
@@ -6,12 +6,12 @@ use common::{INIT, tracing_stderr_init};
 use futures::FutureExt as _;
 use futures::sink::SinkExt;
 use futures::stream::{self, StreamExt};
-use handshake::transports::TcpTransport;
-use handshake::{
+use torrust_handshake::transports::TcpTransport;
+use torrust_handshake::{
     DiscoveryInfo, Extensions, FilterDecision, HandshakeFilter, HandshakeFilters, HandshakerBuilder, InitiateMessage, Protocol,
 };
+use torrust_util::bt::{self, InfoHash, PeerId};
 use tracing::level_filters::LevelFilter;
-use util::bt::{self, InfoHash, PeerId};
 
 mod common;
 

--- a/packages/handshake/tests/test_filter_block_all.rs
+++ b/packages/handshake/tests/test_filter_block_all.rs
@@ -6,12 +6,12 @@ use common::{INIT, tracing_stderr_init};
 use futures::FutureExt;
 use futures::sink::SinkExt;
 use futures::stream::{self, StreamExt};
-use handshake::transports::TcpTransport;
-use handshake::{
+use torrust_handshake::transports::TcpTransport;
+use torrust_handshake::{
     DiscoveryInfo, Extensions, FilterDecision, HandshakeFilter, HandshakeFilters, HandshakerBuilder, InitiateMessage, Protocol,
 };
+use torrust_util::bt::{self, InfoHash, PeerId};
 use tracing::level_filters::LevelFilter;
-use util::bt::{self, InfoHash, PeerId};
 
 mod common;
 

--- a/packages/handshake/tests/test_filter_whitelist_diff_data.rs
+++ b/packages/handshake/tests/test_filter_whitelist_diff_data.rs
@@ -5,10 +5,12 @@ use common::{INIT, tracing_stderr_init};
 use futures::FutureExt as _;
 use futures::sink::SinkExt;
 use futures::stream::{self, StreamExt};
-use handshake::transports::TcpTransport;
-use handshake::{DiscoveryInfo, FilterDecision, HandshakeFilter, HandshakeFilters, HandshakerBuilder, InitiateMessage, Protocol};
+use torrust_handshake::transports::TcpTransport;
+use torrust_handshake::{
+    DiscoveryInfo, FilterDecision, HandshakeFilter, HandshakeFilters, HandshakerBuilder, InitiateMessage, Protocol,
+};
+use torrust_util::bt::{self, InfoHash};
 use tracing::level_filters::LevelFilter;
-use util::bt::{self, InfoHash};
 
 mod common;
 

--- a/packages/handshake/tests/test_filter_whitelist_same_data.rs
+++ b/packages/handshake/tests/test_filter_whitelist_same_data.rs
@@ -5,10 +5,12 @@ use common::{INIT, tracing_stderr_init};
 use futures::FutureExt as _;
 use futures::sink::SinkExt;
 use futures::stream::{self, StreamExt};
-use handshake::transports::TcpTransport;
-use handshake::{DiscoveryInfo, FilterDecision, HandshakeFilter, HandshakeFilters, HandshakerBuilder, InitiateMessage, Protocol};
+use torrust_handshake::transports::TcpTransport;
+use torrust_handshake::{
+    DiscoveryInfo, FilterDecision, HandshakeFilter, HandshakeFilters, HandshakerBuilder, InitiateMessage, Protocol,
+};
+use torrust_util::bt::{self, InfoHash};
 use tracing::level_filters::LevelFilter;
-use util::bt::{self, InfoHash};
 
 mod common;
 

--- a/packages/magnet/Cargo.toml
+++ b/packages/magnet/Cargo.toml
@@ -10,11 +10,11 @@ documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = false                # override with publish = true when ready for a public release
 rust-version.workspace = true
 
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/packages/magnet/Cargo.toml
+++ b/packages/magnet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Magnet link parsing and construction"
 keywords = [ "bittorrent", "magnet" ]
-name = "magnet"
+name = "torrust-magnet"
 readme = "README.md"
 
 authors.workspace = true
@@ -20,7 +20,7 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-util = { path = "../util" }
+torrust-util = { path = "../util" }
 
 base32 = "0"
 url = "2"

--- a/packages/magnet/src/lib.rs
+++ b/packages/magnet/src/lib.rs
@@ -1,6 +1,6 @@
+use torrust_util::bt::InfoHash;
+use torrust_util::sha::ShaHash;
 use url::Url;
-use util::bt::InfoHash;
-use util::sha::ShaHash;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Topic {
@@ -110,7 +110,7 @@ impl MagnetLink {
 
 #[cfg(test)]
 mod tests {
-    use util::sha::ShaHash;
+    use torrust_util::sha::ShaHash;
 
     #[test]
     fn test_wikipedia() {

--- a/packages/metainfo/Cargo.toml
+++ b/packages/metainfo/Cargo.toml
@@ -10,11 +10,11 @@ documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = false                # override with publish = true when ready for a public release
 rust-version.workspace = true
 
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/packages/metainfo/Cargo.toml
+++ b/packages/metainfo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Parsing and building of bittorrent metainfo files"
 keywords = [ "bittorrent", "file", "metainfo", "torrent" ]
-name = "metainfo"
+name = "torrust-metainfo"
 readme = "README.md"
 
 authors.workspace = true
@@ -20,8 +20,8 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-bencode = { path = "../bencode" }
-util = { path = "../util" }
+torrust-bencode = { path = "../bencode" }
+torrust-util = { path = "../util" }
 
 crossbeam = "0"
 thiserror = "2"

--- a/packages/metainfo/benches/metainfo_benchmark.rs
+++ b/packages/metainfo/benches/metainfo_benchmark.rs
@@ -1,7 +1,7 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use metainfo::{DirectAccessor, Metainfo, MetainfoBuilder};
+use torrust_metainfo::{DirectAccessor, Metainfo, MetainfoBuilder};
 
 const MULTI_KB_METAINFO: &[u8; 30004] = include_bytes!("multi_kb.metainfo");
 

--- a/packages/metainfo/examples/create_torrent.rs
+++ b/packages/metainfo/examples/create_torrent.rs
@@ -4,9 +4,9 @@ use std::io::{BufRead as _, Write as _};
 use std::path::Path;
 
 use chrono::offset::{TimeZone, Utc};
-use metainfo::error::ParseError;
-use metainfo::{Metainfo, MetainfoBuilder};
 use pbr::ProgressBar;
+use torrust_metainfo::error::ParseError;
+use torrust_metainfo::{Metainfo, MetainfoBuilder};
 
 fn main() {
     println!("\nIMPORTANT: Remember to run in release mode for real world performance...\n");

--- a/packages/metainfo/src/accessor.rs
+++ b/packages/metainfo/src/accessor.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use util::sha::ShaHash;
+use torrust_util::sha::ShaHash;
 use walkdir::{self, DirEntry, WalkDir};
 
 /// Trait for types convertible as a Result into some Accessor.

--- a/packages/metainfo/src/builder/mod.rs
+++ b/packages/metainfo/src/builder/mod.rs
@@ -1,7 +1,7 @@
 use std::iter::ExactSizeIterator;
 
-use bencode::{BMutAccess, BRefAccess, BencodeMut, ben_bytes, ben_int, ben_map};
-use util::sha::{self, ShaHash};
+use torrust_bencode::{BMutAccess, BRefAccess, BencodeMut, ben_bytes, ben_int, ben_map};
+use torrust_util::sha::{self, ShaHash};
 
 use crate::accessor::{Accessor, IntoAccessor};
 use crate::error::ParseError;

--- a/packages/metainfo/src/builder/worker.rs
+++ b/packages/metainfo/src/builder/worker.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, mpsc};
 
 use crossbeam::queue::SegQueue;
-use util::sha::ShaHash;
+use torrust_util::sha::ShaHash;
 
 use crate::accessor::{Accessor, PieceAccess};
 use crate::builder::buffer::{PieceBuffer, PieceBuffers};
@@ -204,7 +204,7 @@ mod tests {
     use std::path::Path;
     use std::sync::mpsc;
 
-    use util::sha::ShaHash;
+    use torrust_util::sha::ShaHash;
 
     use crate::accessor::{Accessor, PieceAccess};
     use crate::builder::worker;

--- a/packages/metainfo/src/error.rs
+++ b/packages/metainfo/src/error.rs
@@ -1,7 +1,7 @@
 //! Errors for torrent file building and parsing.
 
-use bencode::{BencodeConvertError, BencodeParseError};
 use thiserror::Error;
+use torrust_bencode::{BencodeConvertError, BencodeParseError};
 use walkdir;
 
 #[allow(clippy::module_name_repetitions)]

--- a/packages/metainfo/src/iter.rs
+++ b/packages/metainfo/src/iter.rs
@@ -1,6 +1,6 @@
 //! Iterators over torrent file information.
 
-use util::sha;
+use torrust_util::sha;
 
 use crate::metainfo::File;
 

--- a/packages/metainfo/src/lib.rs
+++ b/packages/metainfo/src/lib.rs
@@ -5,8 +5,6 @@
 //! Building and parsing a metainfo file from a directory:
 //!
 //! ```rust
-//!     extern crate metainfo;
-//!
 //!     use torrust_metainfo::{MetainfoBuilder, Metainfo};
 //!
 //!     fn main() {
@@ -28,8 +26,6 @@
 //! Building and parsing a metainfo file from direct data:
 //!
 //! ```rust
-//!     extern crate metainfo;
-//!
 //!     use torrust_metainfo::{MetainfoBuilder, Metainfo, DirectAccessor};
 //!
 //!     fn main() {

--- a/packages/metainfo/src/lib.rs
+++ b/packages/metainfo/src/lib.rs
@@ -7,7 +7,7 @@
 //! ```rust
 //!     extern crate metainfo;
 //!
-//!     use metainfo::{MetainfoBuilder, Metainfo};
+//!     use torrust_metainfo::{MetainfoBuilder, Metainfo};
 //!
 //!     fn main() {
 //!         let builder = MetainfoBuilder::new()
@@ -30,7 +30,7 @@
 //! ```rust
 //!     extern crate metainfo;
 //!
-//!     use metainfo::{MetainfoBuilder, Metainfo, DirectAccessor};
+//!     use torrust_metainfo::{MetainfoBuilder, Metainfo, DirectAccessor};
 //!
 //!     fn main() {
 //!         let builder = MetainfoBuilder::new()
@@ -66,7 +66,7 @@ mod parse;
 
 pub mod iter;
 
-pub use util::bt::InfoHash;
+pub use torrust_util::bt::InfoHash;
 
 pub use self::metainfo::{File, Info, Metainfo};
 pub use crate::accessor::{Accessor, DirectAccessor, FileAccessor, IntoAccessor, PieceAccess};

--- a/packages/metainfo/src/metainfo.rs
+++ b/packages/metainfo/src/metainfo.rs
@@ -2,9 +2,9 @@
 
 use std::path::{Path, PathBuf};
 
-use bencode::{BDecodeOpt, BDictAccess, BRefAccess, BencodeRef};
-use util::bt::InfoHash;
-use util::sha::{self, ShaHash};
+use torrust_bencode::{BDecodeOpt, BDictAccess, BRefAccess, BencodeRef};
+use torrust_util::bt::InfoHash;
+use torrust_util::sha::{self, ShaHash};
 
 use crate::accessor::{Accessor, IntoAccessor, PieceAccess};
 use crate::builder::{InfoBuilder, MetainfoBuilder, PieceLength};
@@ -460,9 +460,9 @@ impl File {
 mod tests {
     use std::path::{Path, PathBuf};
 
-    use bencode::{BMutAccess, BencodeMut, ben_bytes, ben_int};
-    use util::bt::InfoHash;
-    use util::sha;
+    use torrust_bencode::{BMutAccess, BencodeMut, ben_bytes, ben_int};
+    use torrust_util::bt::InfoHash;
+    use torrust_util::sha;
 
     use crate::metainfo::Metainfo;
     use crate::parse;

--- a/packages/metainfo/src/parse.rs
+++ b/packages/metainfo/src/parse.rs
@@ -1,4 +1,4 @@
-use bencode::{BConvert, BDictAccess, BListAccess, BRefAccess, BencodeConvertError};
+use torrust_bencode::{BConvert, BDictAccess, BListAccess, BRefAccess, BencodeConvertError};
 
 use crate::error::ParseError;
 
@@ -64,11 +64,11 @@ where
     B: BRefAccess<BType = B>,
 {
     list.into_iter()
-        .filter_map(bencode::BRefAccess::list)
+        .filter_map(torrust_bencode::BRefAccess::list)
         .map(|entry| {
             entry
                 .into_iter()
-                .filter_map(bencode::BRefAccess::str)
+                .filter_map(torrust_bencode::BRefAccess::str)
                 .map(String::from)
                 .collect()
         })

--- a/packages/metainfo/tests/test_builder.rs
+++ b/packages/metainfo/tests/test_builder.rs
@@ -1,4 +1,4 @@
-use metainfo::MetainfoBuilder;
+use torrust_metainfo::MetainfoBuilder;
 
 const TRACKER: &str = "udp://foo.bar.baz:6969";
 const DATE: i64 = 1_517_651_523_851;

--- a/packages/peer/Cargo.toml
+++ b/packages/peer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Communication with bittorrent peers via peer wire protocol"
 keywords = [ "bittorrent", "peer", "protocol", "pwp", "wire" ]
-name = "peer"
+name = "torrust-peer"
 readme = "README.md"
 
 authors.workspace = true
@@ -20,9 +20,9 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-bencode = { path = "../bencode" }
-handshake = { path = "../handshake" }
-util = { path = "../util" }
+torrust-bencode = { path = "../bencode" }
+torrust-handshake = { path = "../handshake" }
+torrust-util = { path = "../util" }
 
 byteorder = "1"
 bytes = "1"

--- a/packages/peer/Cargo.toml
+++ b/packages/peer/Cargo.toml
@@ -10,11 +10,11 @@ documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = false                # override with publish = true when ready for a public release
 rust-version.workspace = true
 
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/packages/peer/src/manager/peer_info.rs
+++ b/packages/peer/src/manager/peer_info.rs
@@ -1,8 +1,8 @@
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 
-use handshake::Extensions;
-use util::bt::{InfoHash, PeerId};
+use torrust_handshake::Extensions;
+use torrust_util::bt::{InfoHash, PeerId};
 
 /// Information that uniquely identifies a peer.
 ///

--- a/packages/peer/src/message/bencode_util.rs
+++ b/packages/peer/src/message/bencode_util.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str;
 
-use bencode::{BConvert, BDictAccess, BRefAccess, BencodeConvertError};
-use util::convert;
+use torrust_bencode::{BConvert, BDictAccess, BRefAccess, BencodeConvertError};
+use torrust_util::convert;
 
 use crate::message::bits_ext::ExtendedType;
 

--- a/packages/peer/src/message/bits_ext/handshake.rs
+++ b/packages/peer/src/message/bits_ext/handshake.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::io::Write as _;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use bencode::{BConvert, BDecodeOpt, BMutAccess, BencodeMut, BencodeRef, ben_bytes, ben_int};
 use bytes::{Bytes, BytesMut};
 use nom::{IResult, Needed};
-use util::convert;
+use torrust_bencode::{BConvert, BDecodeOpt, BMutAccess, BencodeMut, BencodeRef, ben_bytes, ben_int};
+use torrust_util::convert;
 
 use crate::message;
 use crate::message::{bencode_util, bits_ext};

--- a/packages/peer/src/message/bits_ext/mod.rs
+++ b/packages/peer/src/message/bits_ext/mod.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::io::Write as _;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use bencode::{BConvert, BDecodeOpt, BMutAccess, BencodeMut, BencodeRef};
 use byteorder::{BigEndian, WriteBytesExt};
 use bytes::Bytes;
 use nom::branch::alt;
@@ -11,7 +10,8 @@ use nom::combinator::map;
 use nom::error::Error;
 use nom::number::complete::{be_u8, be_u16, be_u32};
 use nom::{IResult, Parser};
-use util::convert;
+use torrust_bencode::{BConvert, BDecodeOpt, BMutAccess, BencodeMut, BencodeRef};
+use torrust_util::convert;
 
 use crate::message;
 use crate::message::bencode_util;

--- a/packages/peer/src/message/prot_ext/mod.rs
+++ b/packages/peer/src/message/prot_ext/mod.rs
@@ -3,7 +3,6 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use bencode::{BConvert, BDecodeOpt, BencodeRef};
 use byteorder::{BigEndian, WriteBytesExt};
 use bytes::Bytes;
 use nom::branch::alt;
@@ -15,6 +14,7 @@ use nom::number::complete::{be_u8, be_u32};
 use nom::sequence::pair;
 use nom::{IResult, Parser};
 use thiserror::Error;
+use torrust_bencode::{BConvert, BDecodeOpt, BencodeRef};
 use ut_metadata::UtMetadataMessageError;
 
 use crate::message::{self, ExtendedMessage, ExtendedType, PeerWireProtocolMessage, bencode_util, bits_ext};

--- a/packages/peer/src/message/prot_ext/ut_metadata.rs
+++ b/packages/peer/src/message/prot_ext/ut_metadata.rs
@@ -1,8 +1,8 @@
 use std::io::Write as _;
 
-use bencode::{BConvert, BDecodeOpt, BencodeRef, ben_int, ben_map};
 use bytes::Bytes;
 use thiserror::Error;
+use torrust_bencode::{BConvert, BDecodeOpt, BencodeRef, ben_int, ben_map};
 
 use super::PeerExtensionProtocolMessageError;
 use crate::message::bencode_util;

--- a/packages/peer/tests/common/mod.rs
+++ b/packages/peer/tests/common/mod.rs
@@ -5,10 +5,10 @@ use futures::channel::mpsc::SendError;
 use futures::sink::Sink;
 use futures::stream::Stream;
 use futures::{SinkExt as _, StreamExt as _, TryStream};
-use peer::error::PeerManagerError;
-use peer::{ManagedMessage, PeerInfo, PeerManagerInputMessage, PeerManagerOutputError, PeerManagerOutputMessage};
 use thiserror::Error;
 use tokio::time::error::Elapsed;
+use torrust_peer::error::PeerManagerError;
+use torrust_peer::{ManagedMessage, PeerInfo, PeerManagerInputMessage, PeerManagerOutputError, PeerManagerOutputMessage};
 use tracing::level_filters::LevelFilter;
 
 pub mod connected_channel;

--- a/packages/peer/tests/peer_manager_send_backpressure.rs
+++ b/packages/peer/tests/peer_manager_send_backpressure.rs
@@ -1,13 +1,13 @@
 use common::connected_channel::{ConnectedChannel, connected_channel};
 use common::{INIT, add_peer, remove_peer, tracing_stderr_init};
 use futures::SinkExt as _;
-use handshake::Extensions;
-use peer::error::PeerManagerError;
-use peer::messages::PeerWireProtocolMessage;
-use peer::protocols::NullProtocol;
-use peer::{PeerInfo, PeerManagerBuilder, PeerManagerInputMessage};
+use torrust_handshake::Extensions;
+use torrust_peer::error::PeerManagerError;
+use torrust_peer::messages::PeerWireProtocolMessage;
+use torrust_peer::protocols::NullProtocol;
+use torrust_peer::{PeerInfo, PeerManagerBuilder, PeerManagerInputMessage};
+use torrust_util::bt;
 use tracing::level_filters::LevelFilter;
-use util::bt;
 
 mod common;
 

--- a/packages/select/Cargo.toml
+++ b/packages/select/Cargo.toml
@@ -10,11 +10,11 @@ documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = false                # override with publish = true when ready for a public release
 rust-version.workspace = true
 
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/packages/select/Cargo.toml
+++ b/packages/select/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Torrust BitTorrent Piece Selection Module"
 keywords = [ "piece", "selection" ]
-name = "select"
+name = "torrust-select"
 readme = "README.md"
 
 authors.workspace = true
@@ -20,10 +20,10 @@ version.workspace = true
 workspace = true
 
 [dependencies]
-handshake = { path = "../handshake" }
-metainfo = { path = "../metainfo" }
-peer = { path = "../peer" }
-util = { path = "../util" }
+torrust-handshake = { path = "../handshake" }
+torrust-metainfo = { path = "../metainfo" }
+torrust-peer = { path = "../peer" }
+torrust-util = { path = "../util" }
 
 bit-set = "0"
 bytes = "1"

--- a/packages/select/src/discovery/error.rs
+++ b/packages/select/src/discovery/error.rs
@@ -1,8 +1,8 @@
 //! Module for discovery error types.
 
-use handshake::InfoHash;
-use peer::PeerInfo;
 use thiserror::Error;
+use torrust_handshake::InfoHash;
+use torrust_peer::PeerInfo;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Error, Debug)]

--- a/packages/select/src/discovery/mod.rs
+++ b/packages/select/src/discovery/mod.rs
@@ -1,9 +1,9 @@
 //! Module for peer discovery.
 
-use handshake::InfoHash;
-use metainfo::Metainfo;
-use peer::PeerInfo;
-use peer::messages::UtMetadataMessage;
+use torrust_handshake::InfoHash;
+use torrust_metainfo::Metainfo;
+use torrust_peer::PeerInfo;
+use torrust_peer::messages::UtMetadataMessage;
 
 use crate::ControlMessage;
 

--- a/packages/select/src/discovery/ut_metadata.rs
+++ b/packages/select/src/discovery/ut_metadata.rs
@@ -8,14 +8,14 @@ use std::time::Duration;
 use bytes::BytesMut;
 use futures::sink::Sink;
 use futures::stream::Stream;
-use handshake::InfoHash;
-use metainfo::{Info, Metainfo};
-use peer::PeerInfo;
-use peer::messages::builders::ExtendedMessageBuilder;
-use peer::messages::{
+use rand::RngExt;
+use torrust_handshake::InfoHash;
+use torrust_metainfo::{Info, Metainfo};
+use torrust_peer::PeerInfo;
+use torrust_peer::messages::builders::ExtendedMessageBuilder;
+use torrust_peer::messages::{
     ExtendedMessage, ExtendedType, UtMetadataDataMessage, UtMetadataMessage, UtMetadataRejectMessage, UtMetadataRequestMessage,
 };
-use rand::RngExt;
 
 use crate::ControlMessage;
 use crate::discovery::error::DiscoveryError;

--- a/packages/select/src/extended/mod.rs
+++ b/packages/select/src/extended/mod.rs
@@ -4,9 +4,9 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
 
 use futures::stream::Stream;
-use peer::PeerInfo;
-use peer::messages::ExtendedMessage;
-use peer::messages::builders::ExtendedMessageBuilder;
+use torrust_peer::PeerInfo;
+use torrust_peer::messages::ExtendedMessage;
+use torrust_peer::messages::builders::ExtendedMessageBuilder;
 
 use crate::ControlMessage;
 use crate::error::Error;

--- a/packages/select/src/lib.rs
+++ b/packages/select/src/lib.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use metainfo::Metainfo;
-use peer::PeerInfo;
+use torrust_metainfo::Metainfo;
+use torrust_peer::PeerInfo;
 
 pub mod discovery;
 pub mod error;

--- a/packages/select/src/revelation/error.rs
+++ b/packages/select/src/revelation/error.rs
@@ -1,8 +1,8 @@
 //! Module for revelation error types.
 
-use handshake::InfoHash;
-use peer::PeerInfo;
 use thiserror::Error;
+use torrust_handshake::InfoHash;
+use torrust_peer::PeerInfo;
 
 #[allow(clippy::module_name_repetitions)]
 #[derive(Error, Debug)]

--- a/packages/select/src/revelation/honest.rs
+++ b/packages/select/src/revelation/honest.rs
@@ -6,10 +6,10 @@ use std::task::{Context, Poll, Waker};
 use bit_set::BitSet;
 use bytes::{BufMut, BytesMut};
 use futures::{Sink, Stream};
-use handshake::InfoHash;
-use metainfo::Metainfo;
-use peer::PeerInfo;
-use peer::messages::{BitFieldMessage, HaveMessage};
+use torrust_handshake::InfoHash;
+use torrust_metainfo::Metainfo;
+use torrust_peer::PeerInfo;
+use torrust_peer::messages::{BitFieldMessage, HaveMessage};
 use tracing::instrument;
 
 use crate::ControlMessage;

--- a/packages/select/src/revelation/mod.rs
+++ b/packages/select/src/revelation/mod.rs
@@ -1,8 +1,8 @@
 //! Module for piece revelation.
 
-use handshake::InfoHash;
-use peer::PeerInfo;
-use peer::messages::{BitFieldMessage, HaveMessage};
+use torrust_handshake::InfoHash;
+use torrust_peer::PeerInfo;
+use torrust_peer::messages::{BitFieldMessage, HaveMessage};
 
 use crate::ControlMessage;
 

--- a/packages/select/src/uber/mod.rs
+++ b/packages/select/src/uber/mod.rs
@@ -1,9 +1,9 @@
 use std::sync::{Arc, Mutex};
 
 use futures::{Sink, Stream};
-use peer::messages::builders::ExtendedMessageBuilder;
 use sink::UberSink;
 use stream::UberStream;
+use torrust_peer::messages::builders::ExtendedMessageBuilder;
 
 use crate::ControlMessage;
 use crate::discovery::error::DiscoveryError;

--- a/packages/select/tests/select_tests.rs
+++ b/packages/select/tests/select_tests.rs
@@ -2,15 +2,15 @@ use std::time::Duration;
 
 use common::{INIT, tracing_stderr_init};
 use futures::{SinkExt as _, StreamExt as _};
-use handshake::Extensions;
-use metainfo::{DirectAccessor, Metainfo, MetainfoBuilder, PieceLength};
-use peer::PeerInfo;
-use select::ControlMessage;
-use select::revelation::error::RevealError;
-use select::revelation::{HonestRevealModuleBuilder, IRevealMessage, ORevealMessage};
+use torrust_handshake::Extensions;
+use torrust_metainfo::{DirectAccessor, Metainfo, MetainfoBuilder, PieceLength};
+use torrust_peer::PeerInfo;
+use torrust_select::ControlMessage;
+use torrust_select::revelation::error::RevealError;
+use torrust_select::revelation::{HonestRevealModuleBuilder, IRevealMessage, ORevealMessage};
+use torrust_util::bt;
+use torrust_util::bt::InfoHash;
 use tracing::level_filters::LevelFilter;
-use util::bt;
-use util::bt::InfoHash;
 
 mod common;
 

--- a/packages/util/Cargo.toml
+++ b/packages/util/Cargo.toml
@@ -10,11 +10,11 @@ documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish.workspace = true
+publish = false                # override with publish = true when ready for a public release
 rust-version.workspace = true
 
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lints]
 workspace = true

--- a/packages/util/Cargo.toml
+++ b/packages/util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Utilities for Torrust BitTorrent"
 keywords = [ "utility" ]
-name = "util"
+name = "torrust-util"
 readme = "README.md"
 
 authors.workspace = true

--- a/project-words.txt
+++ b/project-words.txt
@@ -72,6 +72,7 @@ nodetypes
 oneline
 Oneshot
 openbittorrent
+organisation
 pblock
 peekable
 Pingable
@@ -112,6 +113,7 @@ unchoke
 unchoked
 unpinged
 unscalable
+unvalidated
 upnp
 usize
 utorrent


### PR DESCRIPTION
Closes #80

## Summary

Sets up the crate publishing infrastructure for the workspace as a prerequisite for importing `torrust-tracker-contrib-bencode` (issue #64).

## Changes

### Task 1+3 — Publish strategy and independent versioning

- Root `[workspace.package]` keeps `publish = false` as the default.  Every crate under `packages/` now explicitly sets `publish = false` with a comment explaining when to flip the flag.
- Removed the shared `version` from `[workspace.package]`; each crate now declares its own `version = "0.1.0"`.

### Task 2 — Rename crates with `torrust-` prefix

All 9 crates renamed following DEC-02/03/04 from the torrust-tracker DECISIONS.md:

| Old name   | New name           |
|------------|--------------------|
| bencode    | torrust-bencode    |
| dht        | torrust-dht        |
| disk       | torrust-disk       |
| handshake  | torrust-handshake  |
| magnet     | torrust-magnet     |
| metainfo   | torrust-metainfo   |
| peer       | torrust-peer       |
| select     | torrust-select     |
| util       | torrust-util       |

Folder names under `packages/` are unchanged. All inter-crate `Cargo.toml` dependency keys and all Rust `use` / fully-qualified paths updated accordingly.

### Task 4 — ADR

`docs/adrs/20260605103740_crate_publishing_and_versioning.md` — records the naming, publish-on-demand, and independent-versioning decisions. `docs/adrs/index.md` added.

### Task 5 — Release-package skill

`.github/skills/dev/maintenance/release-package/SKILL.md` — 12-step end-to-end release workflow (version bump → changelog → dry-run → publish → tag → GitHub release).

## Acceptance Criteria

All criteria from the spec are met — see [the spec](docs/issues/0080-setup-package-publishing-infrastructure.md) for the full checklist.

## Related

- Closes #80
- Unblocks #64
