### PR TITLE
feat(bencode): import torrust-tracker-contrib-bencode v3.0.0 and publish as torrust-bencode

### DIFF
--- a/docs/adrs/20260605103740_crate_publishing_and_versioning.md
+++ b/docs/adrs/20260605103740_crate_publishing_and_versioning.md
@@ -73,6 +73,14 @@ Adopted from DEC-02 and DEC-04 of the Torrust Tracker overhaul DECISIONS.md:
 - Every crate in `packages/` carries its own explicit `version` field.
 - All crates start at `0.1.0` regardless of prior crates.io history under different names
   (old names are different crate identities; their version history does not carry over).
+- **Exception — imported crates with an existing published version**: when a crate is imported
+  from another Torrust repository where it was already published to crates.io under a _different_
+  crate name, the version from that prior publication is preserved in this workspace. This avoids
+  confusion for consumers who may be familiar with the prior version number and ensures a clear
+  continuity of the release history. The first version published under the _new_ crate name must
+  therefore be at least as high as the last version published under the old name.
+  Example: `torrust-tracker-contrib-bencode v3.0.0` was imported and renamed to `torrust-bencode`;
+  the version in this workspace is kept at `3.0.0`.
 - Subsequent releases follow [SemVer](https://semver.org/): PATCH for fixes, MINOR for
   new backwards-compatible API, MAJOR for breaking changes.
 - Each crate is released independently; releasing one crate does not require bumping any other.

--- a/docs/issues/0082-import-contrib-bencode-from-torrust-tracker.md
+++ b/docs/issues/0082-import-contrib-bencode-from-torrust-tracker.md
@@ -1,0 +1,95 @@
+---
+doc-type: issue
+issue-type: task
+status: open
+priority: p1
+github-issue: 82
+spec-path: docs/issues/0082-import-contrib-bencode-from-torrust-tracker.md
+branch: 82-import-contrib-bencode-from-torrust-tracker
+related-pr: null
+last-updated-utc: 2026-06-05 14:00
+semantic-links:
+  skill-links:
+    - release-package
+  related-artifacts:
+    - packages/bencode/Cargo.toml
+    - packages/bencode/src/
+    - docs/adrs/20260605103740_crate_publishing_and_versioning.md
+  external-links:
+    - https://github.com/torrust/torrust-tracker/issues/1881
+    - https://crates.io/crates/torrust-tracker-contrib-bencode
+---
+
+# Import `torrust-tracker-contrib-bencode` from Torrust Tracker
+
+## Summary
+
+Import the updated `bencode` package from [torrust/torrust-tracker](https://github.com/torrust/torrust-tracker)
+into this workspace as `torrust-bencode`, preserving the version `3.0.0` that was previously published to
+crates.io under the name `torrust-tracker-contrib-bencode`.
+
+## Motivation
+
+The `bencode` package in this workspace was originally forked from the unmaintained
+[GGist/bip-rs](https://github.com/GGist/bip-rs). In parallel, Cameron ([@da2ce7](https://github.com/da2ce7))
+had already updated and published a refined version of the same package from within the
+`torrust/torrust-tracker` workspace as `torrust-tracker-contrib-bencode v3.0.0`.
+
+When this repository was set up as the canonical home for BitTorrent infrastructure crates, those
+tracker-side improvements had not yet been back-ported. This task closes that gap by importing the
+changes from `torrust/torrust-tracker` into `packages/bencode` and publishing the result as the
+new `torrust-bencode` crate on crates.io.
+
+## Background
+
+- The corresponding tracker-side issue is [torrust/torrust-tracker#1881](https://github.com/torrust/torrust-tracker/issues/1881).
+- The previously published crate: [crates.io/crates/torrust-tracker-contrib-bencode v3.0.0](https://crates.io/crates/torrust-tracker-contrib-bencode).
+- The ADR [docs/adrs/20260605103740_crate_publishing_and_versioning.md](../adrs/20260605103740_crate_publishing_and_versioning.md)
+  was updated to include an exception for this case: imported crates that were already published
+  under a different name retain their prior version number rather than resetting to `0.1.0`.
+
+## Scope
+
+### 1. Import source changes from `torrust/torrust-tracker`
+
+Apply the following changes from `torrust-tracker/contrib/bencode` to `packages/bencode`:
+
+| File                      | Change                                                     |
+| ------------------------- | ---------------------------------------------------------- |
+| `Cargo.toml`              | Set `publish = true`, `version = "3.0.0"`, update keywords |
+| `src/access/convert.rs`   | Refactor `lookup` call to use `map_or_else` (clippy fix)   |
+| `src/lib.rs`              | Add `extern crate` and `#[macro_use]` to doc examples      |
+| `src/reference/decode.rs` | Add blank line for readability                             |
+
+### 2. Update ADR versioning policy
+
+Amend `docs/adrs/20260605103740_crate_publishing_and_versioning.md` to document the exception:
+when a crate is imported from another Torrust repository where it was already published under a
+different name, the prior version is preserved to maintain continuity for existing consumers.
+
+### 3. Publish `torrust-bencode` to crates.io
+
+Perform a dry-run first (`cargo publish -p torrust-bencode --dry-run`), then publish the crate
+as `torrust-bencode v3.0.0`.
+
+## Acceptance Criteria
+
+- [ ] `packages/bencode/Cargo.toml` has `publish = true` and `version = "3.0.0"`.
+- [ ] All source changes from `torrust-tracker-contrib-bencode v3.0.0` are applied to `packages/bencode/src/`.
+- [ ] `cargo check --workspace --all-targets --all-features` passes.
+- [ ] `cargo nextest run -p torrust-bencode` passes.
+- [ ] `cargo publish -p torrust-bencode --dry-run` succeeds.
+- [ ] `linter all` passes.
+- [ ] ADR updated with the imported-crate version exception policy.
+- [ ] GitHub issue opened with a link to [torrust/torrust-tracker#1881](https://github.com/torrust/torrust-tracker/issues/1881).
+
+## Out of Scope
+
+- Importing other packages from `torrust/torrust-tracker` (separate issues).
+- Any API changes beyond what was already in `torrust-tracker-contrib-bencode v3.0.0`.
+
+## Related
+
+- [torrust/torrust-tracker#1881](https://github.com/torrust/torrust-tracker/issues/1881) — corresponding tracker-side issue.
+- [crates.io/crates/torrust-tracker-contrib-bencode](https://crates.io/crates/torrust-tracker-contrib-bencode) — prior published crate.
+- [#80](https://github.com/torrust/torrust-bittorrent/issues/80) — package publishing infrastructure (prerequisite).

--- a/docs/issues/closed/0077-add-agent-infrastructure.md
+++ b/docs/issues/closed/0077-add-agent-infrastructure.md
@@ -4,7 +4,7 @@ issue-type: task
 status: closed
 priority: p2
 github-issue: 77
-spec-path: docs/issues/0077-add-agent-infrastructure.md
+spec-path: docs/issues/closed/0077-add-agent-infrastructure.md
 branch: chore/add-agent-infrastructure
 related-pr: 79
 last-updated-utc: 2026-06-04 16:37

--- a/docs/issues/closed/0080-setup-package-publishing-infrastructure.md
+++ b/docs/issues/closed/0080-setup-package-publishing-infrastructure.md
@@ -4,7 +4,7 @@ issue-type: task
 status: closed
 priority: p2
 github-issue: 80
-spec-path: docs/issues/0080-setup-package-publishing-infrastructure.md
+spec-path: docs/issues/closed/0080-setup-package-publishing-infrastructure.md
 branch: chore/setup-package-publishing-infrastructure
 related-pr: 81
 last-updated-utc: 2026-06-05 11:30

--- a/docs/issues/open/0082-import-contrib-bencode-from-torrust-tracker.md
+++ b/docs/issues/open/0082-import-contrib-bencode-from-torrust-tracker.md
@@ -4,7 +4,7 @@ issue-type: task
 status: open
 priority: p1
 github-issue: 82
-spec-path: docs/issues/0082-import-contrib-bencode-from-torrust-tracker.md
+spec-path: docs/issues/open/0082-import-contrib-bencode-from-torrust-tracker.md
 branch: 82-import-contrib-bencode-from-torrust-tracker
 related-pr: null
 last-updated-utc: 2026-06-05 14:00

--- a/docs/issues/open/0082-import-contrib-bencode-from-torrust-tracker.md
+++ b/docs/issues/open/0082-import-contrib-bencode-from-torrust-tracker.md
@@ -44,7 +44,7 @@ new `torrust-bencode` crate on crates.io.
 
 - The corresponding tracker-side issue is [torrust/torrust-tracker#1881](https://github.com/torrust/torrust-tracker/issues/1881).
 - The previously published crate: [crates.io/crates/torrust-tracker-contrib-bencode v3.0.0](https://crates.io/crates/torrust-tracker-contrib-bencode).
-- The ADR [docs/adrs/20260605103740_crate_publishing_and_versioning.md](../adrs/20260605103740_crate_publishing_and_versioning.md)
+- The ADR [docs/adrs/20260605103740_crate_publishing_and_versioning.md](../../adrs/20260605103740_crate_publishing_and_versioning.md)
   was updated to include an exception for this case: imported crates that were already published
   under a different name retain their prior version number rather than resetting to `0.1.0`.
 

--- a/packages/bencode/Cargo.toml
+++ b/packages/bencode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 description = "Efficient decoding and encoding for bencode."
-keywords = [ "bencode" ]
+keywords = [ "bencode", "bittorrent", "library" ]
 name = "torrust-bencode"
 readme = "README.md"
 
@@ -10,11 +10,14 @@ documentation.workspace = true
 edition.workspace = true
 homepage.workspace = true
 license.workspace = true
-publish = false                # override with publish = true when ready for a public release
+publish = true
 rust-version.workspace = true
 
 repository.workspace = true
-version = "0.1.0"
+# Version kept at 3.0.0 to match the previously published torrust-tracker-contrib-bencode v3.0.0.
+# See ADR docs/adrs/20260605103740_crate_publishing_and_versioning.md for the exception policy
+# on imported crates that carry an existing published version.
+version = "3.0.0"
 
 [lints]
 workspace = true

--- a/packages/bencode/README.md
+++ b/packages/bencode/README.md
@@ -1,5 +1,28 @@
-# Bencode
+# torrust-bencode
+
+[![Crates.io](https://img.shields.io/crates/v/torrust-bencode.svg)](https://crates.io/crates/torrust-bencode)
 
 This library allows for the creation and parsing of bencode encodings.
 
 Bencode is the binary encoding used throughout bittorrent technologies from metainfo files to DHT messages. Bencode types include integers, byte arrays, lists, and dictionaries, of which the last two can hold any bencode type (they could be recursively constructed).
+
+## Package History
+
+This crate has moved through several repositories and crate names:
+
+| Period   | Repository                                                                                       | Crate name on crates.io                                                                                                      |
+| -------- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| Original | [GGist/bip-rs](https://github.com/GGist/bip-rs)                                                  | `bip-bencode` (unpublished / abandoned)                                                                                      |
+| Interim  | [torrust/torrust-tracker](https://github.com/torrust/torrust-tracker) (`contrib/bencode`)        | [`torrust-tracker-contrib-bencode`](https://crates.io/crates/torrust-tracker-contrib-bencode) — last published as **v3.0.0** |
+| Current  | [torrust/torrust-bittorrent](https://github.com/torrust/torrust-bittorrent) (`packages/bencode`) | [`torrust-bencode`](https://crates.io/crates/torrust-bencode) — from **v3.0.0** onwards                                      |
+
+### Why did the crate name change?
+
+When the Torrust project consolidated its BitTorrent infrastructure libraries into the dedicated
+`torrust-bittorrent` workspace, the `bencode` package was migrated here from `torrust-tracker`
+where it had been maintained as a contrib package. The new crate name `torrust-bencode` follows
+the organisation-wide naming convention (`torrust-<short-name>`) established in the
+[publishing and versioning ADR](../../docs/adrs/20260605103740_crate_publishing_and_versioning.md).
+
+The version number was preserved at `3.0.0` to avoid confusion for consumers already using
+`torrust-tracker-contrib-bencode v3.0.0` — the code is identical.

--- a/packages/bencode/src/access/convert.rs
+++ b/packages/bencode/src/access/convert.rs
@@ -157,9 +157,10 @@ pub trait BConvert {
     {
         let key_ref = key.as_ref();
 
-        dictionary
-            .lookup(key_ref)
-            .ok_or_else(|| self.handle_error(BencodeConvertError::MissingKey { key: key_ref.to_owned() }))
+        dictionary.lookup(key_ref).map_or_else(
+            || Err(self.handle_error(BencodeConvertError::MissingKey { key: key_ref.to_owned() })),
+            Ok,
+        )
     }
 
     /// Combines a lookup operation on the given key with a conversion of the value, if found, to an integer.

--- a/packages/bencode/src/lib.rs
+++ b/packages/bencode/src/lib.rs
@@ -5,6 +5,8 @@
 //! Decoding bencoded data:
 //!
 //! ```rust
+//!     extern crate torrust_bencode;
+//!
 //!     use torrust_bencode::{BencodeRef, BRefAccess, BDecodeOpt};
 //!
 //!     fn main() {
@@ -19,7 +21,8 @@
 //! Encoding bencoded data:
 //!
 //! ```rust
-//!     use torrust_bencode::{ben_map, ben_int, ben_bytes};
+//!     #[macro_use]
+//!     extern crate torrust_bencode;
 //!
 //!     fn main() {
 //!         let message = (ben_map!{

--- a/packages/bencode/src/reference/decode.rs
+++ b/packages/bencode/src/reference/decode.rs
@@ -129,6 +129,7 @@ fn decode_dict(
             }
             _ => (),
         }
+
         curr_pos = next_pos;
 
         let (value, next_pos) = decode(bytes, curr_pos, opts, depth + 1)?;


### PR DESCRIPTION
## Summary

Import the updated bencode package from [torrust/torrust-tracker](https://github.com/torrust/torrust-tracker) into this workspace as `torrust-bencode v3.0.0`, preserving the version from the previously published `torrust-tracker-contrib-bencode v3.0.0`.

Also reorganizes `docs/issues/` into `drafts/`, `open/`, and `closed/` subdirectories to match the workflow defined in the `create-issue` skill.

Closes #82.
Related to torrust/torrust-tracker#1881.

## Changes

### feat(bencode): import torrust-tracker-contrib-bencode v3.0.0 changes

- `packages/bencode/Cargo.toml`: set `publish = true`, `version = "3.0.0"`, update keywords
- `src/access/convert.rs`: refactor `lookup` to use `map_or_else` (clippy fix)
- `src/lib.rs`: add `extern crate` and `#[macro_use]` to doc examples
- `src/reference/decode.rs`: add blank line for readability
- ADR updated with exception policy for imported crates that carry an existing published version

### docs(issues): add issue specification for #82

Spec at `docs/issues/open/0082-import-contrib-bencode-from-torrust-tracker.md`.

### refactor(issues): reorganize docs/issues into drafts/, open/, and closed/

Closes #83.

## Checklist

- [x] `cargo check --workspace --all-targets --all-features` passes
- [x] `cargo test -p torrust-bencode` passes (45 unit + 2 integration + 2 doc tests)
- [x] `cargo clippy -p torrust-bencode` clean
- [x] `cargo publish -p torrust-bencode --dry-run` succeeds
- [x] `linter all` passes