### PR TITLE
feat(info-hash): add torrust-info-hash package from bittorrent-primitives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ workspace under the `torrust-bittorrent` umbrella.
 | `dht`       | `packages/dht`       | BitTorrent Mainline DHT                                  |
 | `disk`      | `packages/disk`      | FileSystem interface for managing torrent pieces on disk |
 | `handshake` | `packages/handshake` | Standard BitTorrent handshake trait and implementation   |
+| `info-hash` | `packages/info-hash` | BitTorrent InfoHash v1 type                              |
 | `magnet`    | `packages/magnet`    | Parsing and constructing magnet links                    |
 | `metainfo`  | `packages/metainfo`  | Parsing and building `.torrent` metainfo files           |
 | `peer`      | `packages/peer`      | Peer wire protocol communication                         |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "packages/dht",
   "packages/disk",
   "packages/handshake",
+  "packages/info-hash",
   "packages/magnet",
   "packages/metainfo",
   "packages/peer",

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The original crates were published under the `bip_` prefix, short for _BitTorren
 
 > **_Please note:_** The license of this repository has been changed!
 >
-> > `Apache-2.0`　and/or　`MIT`　→　*(only)*　`Apache-2.0`
+> > `Apache-2.0`　and/or　`MIT`　→　_(only)_　`Apache-2.0`
 >
 > If this is a particular issue for your project, please open an issue.<br>
 > _The primary motivation that it has [some software-patent protections][apache-2-patent-license]._

--- a/docs/issues/open/0087-add-info-hash-package-from-bittorrent-primitives.md
+++ b/docs/issues/open/0087-add-info-hash-package-from-bittorrent-primitives.md
@@ -1,0 +1,154 @@
+---
+doc-type: issue
+issue-type: task
+status: open
+priority: p1
+github-issue: 87
+spec-path: docs/issues/open/0087-add-info-hash-package-from-bittorrent-primitives.md
+branch: feat/add-info-hash-from-bittorrent-primitives
+last-updated-utc: 2026-06-08 12:00
+semantic-links:
+  skill-links:
+    - release-package
+  related-artifacts:
+    - packages/info-hash/Cargo.toml
+    - packages/info-hash/src/
+    - Cargo.toml
+  external-links:
+    - https://github.com/torrust/bittorrent-primitives
+    - https://github.com/torrust/bittorrent-primitives/issues/5
+    - https://github.com/torrust/torrust-bittorrent/issues/64
+---
+
+# Add `torrust-info-hash` Package from `bittorrent-primitives`
+
+## Summary
+
+Import the `info_hash` module from [torrust/bittorrent-primitives](https://github.com/torrust/bittorrent-primitives)
+as a standalone workspace package `torrust-info-hash 0.1.0` in this repository,
+then publish it to crates.io. This is part of the plan to move individual types
+from the shared `bittorrent-primitives` crate into dedicated packages under this
+workspace.
+
+The original migration tracking issue is
+[bittorrent-primitives#5](https://github.com/torrust/bittorrent-primitives/issues/5),
+which links to the broader infrastructure plan in
+[torrust-bittorrent#64](https://github.com/torrust/torrust-bittorrent/issues/64).
+
+## Motivation
+
+The `InfoHash` type is needed by multiple Torrust crates (torrust-tracker, torrust-index, etc.).
+Moving it to its own published crate under this workspace allows it to be versioned
+and consumed independently, rather than pulling in the entire `bittorrent-primitives` crate.
+
+## Background
+
+- Source: `src/info_hash.rs` from `torrust/bittorrent-primitives` (main branch).
+- Author: **Jose Celano** (`josecelano@gmail.com`), the original implementation author.
+- The module was copied with workspace-necessary adaptations only — the core
+  implementation is unchanged from the original.
+
+A handoff agent already completed the initial file copy and adaptation (see the
+now-deleted `packages/info-hash/HANDOFF.md`). What remains is finishing the work
+and getting it merged.
+
+## What was already done (by handoff agent)
+
+All changes are unstaged on the current `develop` branch:
+
+| File                                  | Description                                                                               |
+| ------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `packages/info-hash/Cargo.toml`       | Package manifest; crate name `torrust-info-hash` v0.1.0                                   |
+| `packages/info-hash/LICENSE-APACHE`   | Apache-2.0 license (matching workspace)                                                   |
+| `packages/info-hash/README.md`        | Crate docs with origin info and usage example                                             |
+| `packages/info-hash/src/lib.rs`       | Re-exports `InfoHash` from `info_hash` module                                             |
+| `packages/info-hash/src/info_hash.rs` | The `InfoHash` type — faithful copy from `bittorrent-primitives` with minimal adaptations |
+
+### Adaptations from the original
+
+The following differences from the original `info_hash.rs` are intentional and necessary:
+
+1. **`#[cfg(feature = "serde")]` gates** — `serde` is optional (default-on) in this workspace,
+   so the `Serialize`, `Deserialize`, and `InfoHashVisitor` impls are feature-gated.
+2. **`std::convert::From` → `From`** — Rust 2024 edition; qualified paths are unnecessary.
+3. **`#[expect(dead_code, reason = "...")]`** on `fixture::gen_seeded_infohash` — public
+   fixture API for downstream consumers; the lint is expected.
+4. **`#![allow(clippy::module_name_repetitions)]`** in `lib.rs` — workspace lint compliance.
+5. **Crate-level:** name `torrust-info-hash`, edition 2024, license Apache-2.0, `thiserror` v2,
+   `serde_json` moved to dev-dependencies.
+
+### Verified
+
+- ✅ `cargo check -p torrust-info-hash --all-targets --all-features` passes
+- ✅ `cargo nextest run -p torrust-info-hash --all-targets --all-features` — 12/12 tests pass
+- ✅ `cargo test --doc -p torrust-info-hash` passes
+- ✅ `diff` against upstream `info_hash.rs` confirms only the intentional adaptations above
+
+## Scope
+
+### 1. Review the existing file copies
+
+Verify the adaptations are correct and nothing was missed from the handoff.
+
+### 2. Add to workspace
+
+Add `"packages/info-hash"` to the `[workspace] members` list in the root `Cargo.toml`.
+
+### 3. Update `AGENTS.md`
+
+Add a row for the new `info-hash` package to the package table in `AGENTS.md` (alphabetically
+sorted).
+
+### 4. Run full workspace validation
+
+```bash
+cargo check --workspace --all-targets --all-features
+cargo nextest run --workspace --all-targets --all-features
+cargo +nightly fmt --check
+cargo clippy --workspace --all-targets --all-features
+linter all
+```
+
+### 5. Create branch, commit, open PR
+
+- Branch: `feat/add-info-hash-from-bittorrent-primitives`
+- Commit type: `feat(info-hash)` or `refactor(info-hash)`
+- PR against `develop`
+- Preserve original author with `git commit --author="Jose Celano <josecelano@gmail.com>"`
+
+### 6. Merge after CI passes
+
+### 7. Publish `torrust-info-hash 0.1.0` to crates.io
+
+```bash
+cargo publish -p torrust-info-hash --dry-run
+cargo publish -p torrust-info-hash
+```
+
+### 8. Signal back to dependents
+
+Update the relevant tracking issues:
+
+- [bittorrent-primitives#5](https://github.com/torrust/bittorrent-primitives/issues/5) —
+  the `info_hash` module has been migrated.
+- The tracker and index repos should switch to `torrust-info-hash` from crates.io.
+
+## Implementation Plan
+
+| Step | Task                                                              | Status          |
+| ---- | ----------------------------------------------------------------- | --------------- |
+| 1    | Review existing file copies and adaptations                       | ⬜ todo         |
+| 2    | Add `"packages/info-hash"` to root `Cargo.toml` workspace members | ⬜ todo         |
+| 3    | Add `info-hash` row to package table in `AGENTS.md`               | ⬜ todo         |
+| 4    | Run full workspace validation (check, test, fmt, clippy, linter)  | ⬜ todo         |
+| 5    | Create branch and commit with original author attribution         | ⬜ todo         |
+| 6    | Push branch and open PR against `develop`                         | ⬜ todo         |
+| 7    | Merge PR after CI passes                                          | ⬜ todo         |
+| 8    | Publish `torrust-info-hash 0.1.0` to crates.io                    | ⬜ todo         |
+| 9    | Signal tracker repo to switch dependency                          | ↩️ tracker-side |
+
+## Dependencies of the new package
+
+- `binascii` — hex encoding/decoding
+- `serde` (optional, default) — serialization/deserialization
+- `thiserror` — error derive macros

--- a/packages/info-hash/Cargo.toml
+++ b/packages/info-hash/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+description = "BitTorrent InfoHash v1 type for Rust projects."
+keywords = [ "bittorrent", "infohash", "library", "primitives" ]
+name = "torrust-info-hash"
+readme = "README.md"
+version = "0.1.0"
+
+authors.workspace = true
+categories.workspace = true
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+publish = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = [ "serde" ]
+serde = [ "dep:serde" ]
+
+[dependencies]
+binascii = "0.1"
+serde = { version = "1", features = [ "derive" ], optional = true }
+thiserror = "2"
+
+[dev-dependencies]
+serde = { version = "1", features = [ "derive" ] }
+serde_json = "1"

--- a/packages/info-hash/LICENSE-APACHE
+++ b/packages/info-hash/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) The Torrust Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/info-hash/README.md
+++ b/packages/info-hash/README.md
@@ -1,0 +1,38 @@
+# torrust-info-hash
+
+In-house crate for BitTorrent `InfoHash` v1 type.
+
+## Origin and In-House Maintenance
+
+This crate was originally extracted from the standalone
+[torrust/bittorrent-primitives](https://github.com/torrust/bittorrent-primitives)
+repository and moved into the [torrust/torrust-bittorrent](https://github.com/torrust/torrust-bittorrent)
+workspace.
+
+Torrust keeps this package in-house to ensure ongoing maintenance, dependency
+updates, and evolution alongside other BitTorrent primitives.
+
+## Licensing and Notices
+
+The original source is dual-licensed under MIT or Apache-2.0. This in-house
+package is relicensed under Apache-2.0 to match the workspace license.
+
+An explicit copy of Apache-2.0 is included at [LICENSE-APACHE](./LICENSE-APACHE).
+
+## Usage
+
+```rust
+use torrust_info_hash::InfoHash;
+
+let info_hash: InfoHash = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+    .parse()
+    .expect("valid 40-char hex string");
+
+assert_eq!(info_hash.to_hex_string(), "ffffffffffffffffffffffffffffffffffffffff");
+```
+
+## Features
+
+| Feature | Default | Description                      |
+| ------- | ------- | -------------------------------- |
+| `serde` | Yes     | Enable serde serialization/deserialization |

--- a/packages/info-hash/src/info_hash.rs
+++ b/packages/info-hash/src/info_hash.rs
@@ -1,0 +1,489 @@
+//! A `BitTorrent` `InfoHash`. It's a unique identifier for a `BitTorrent` torrent.
+//!
+//! "The 20-byte sha1 hash of the bencoded form of the info value
+//! from the metainfo file."
+//!
+//! See [BEP 3. The `BitTorrent` Protocol Specification](https://www.bittorrent.org/beps/bep_0003.html)
+//! for the official specification.
+//!
+//! This module provides a type that can be used to represent infohashes.
+//!
+//! > **NOTICE**: It only supports Info Hash v1.
+//!
+//! Typically infohashes are represented as hex strings, but internally they are
+//! a 20-byte array.
+//!
+//! # Calculating the info-hash of a torrent file
+//!
+//! A sample torrent:
+//!
+//! - Torrent file: `mandelbrot_2048x2048_infohash_v1.png.torrent`
+//! - File: `mandelbrot_2048x2048.png`
+//! - Info Hash v1: `5452869be36f9f3350ccee6b4544e7e76caaadab`
+//! - Sha1 hash of the info dictionary: `5452869BE36F9F3350CCEE6B4544E7E76CAAADAB`
+//!
+//! A torrent file is a binary file encoded with [Bencode encoding](https://en.wikipedia.org/wiki/Bencode):
+//!
+// cspell:disable
+//! ```text
+//! 0000000: 6431 303a 6372 6561 7465 6420 6279 3138  d10:created by18
+//! 0000010: 3a71 4269 7474 6f72 7265 6e74 2076 342e  :qBittorrent v4.
+//! 0000020: 342e 3131 333a 6372 6561 7469 6f6e 2064  4.113:creation d
+//! 0000030: 6174 6569 3136 3739 3637 3436 3238 6534  atei1679674628e4
+//! 0000040: 3a69 6e66 6f64 363a 6c65 6e67 7468 6931  :infod6:lengthi1
+//! 0000050: 3732 3230 3465 343a 6e61 6d65 3234 3a6d  72204e4:name24:m
+//! 0000060: 616e 6465 6c62 726f 745f 3230 3438 7832  andelbrot_2048x2
+//! 0000070: 3034 382e 706e 6731 323a 7069 6563 6520  048.png12:piece
+//! 0000080: 6c65 6e67 7468 6931 3633 3834 6536 3a70  lengthi16384e6:p
+//! 0000090: 6965 6365 7332 3230 3a7d 9171 0d9d 4dba  ieces220:}.q..M.
+//! 00000a0: 889b 5420 54d5 2672 8d5a 863f e121 df77  ..T T.&r.Z.?.!.w
+//! 00000b0: c7f7 bb6c 7796 2166 2538 c5d9 cdab 8b08  ...lw.!f%8......
+//! 00000c0: ef8c 249b b2f5 c4cd 2adf 0bc0 0cf0 addf  ..$.....*.......
+//! 00000d0: 7290 e5b6 414c 236c 479b 8e9f 46aa 0c0d  r...AL#lG...F...
+//! 00000e0: 8ed1 97ff ee68 8b5f 34a3 87d7 71c5 a6f9  .....h._4...q...
+//! 00000f0: 8e2e a631 7cbd f0f9 e223 f9cc 80af 5400  ...1|....#....T.
+//! 0000100: 04f9 8569 1c77 89c1 764e d6aa bf61 a6c2  ...i.w..vN...a..
+//! 0000110: 8099 abb6 5f60 2f40 a825 be32 a33d 9d07  ...._`/@.%.2.=..
+//! 0000120: 0c79 6898 d49d 6349 af20 5866 266f 986b  .yh...cI. Xf&o.k
+//! 0000130: 6d32 34cd 7d08 155e 1ad0 0009 57ab 303b  m24.}..^....W.0;
+//! 0000140: 2060 c1dc 1287 d6f3 e745 4f70 6709 3631   `.......EOpg.61
+//! 0000150: 55f2 20f6 6ca5 156f 2c89 9569 1653 817d  U. .l..o,..i.S.}
+//! 0000160: 31f1 b6bd 3742 cc11 0bb2 fc2b 49a5 85b6  1...7B.....+I...
+//! 0000170: fc76 7444 9365 65                        .vtD.ee
+//! ```
+// cspell:enable
+//!
+//! You can generate that output with the command:
+//!
+//! ```text
+//! xxd mandelbrot_2048x2048_infohash_v1.png.torrent
+//! ```
+//!
+//! And you can show only the bytes (hexadecimal):
+//!
+//! ```text
+//! 6431303a6372656174656420627931383a71426974746f7272656e742076
+//! 342e342e3131333a6372656174696f6e2064617465693136373936373436
+//! 323865343a696e666f64363a6c656e6774686931373232303465343a6e61
+//! 6d6532343a6d616e64656c62726f745f3230343878323034382e706e6731
+//! 323a7069656365206c656e67746869313633383465363a70696563657332
+//! 32303a7d91710d9d4dba889b542054d526728d5a863fe121df77c7f7bb6c
+//! 779621662538c5d9cdab8b08ef8c249bb2f5c4cd2adf0bc00cf0addf7290
+//! e5b6414c236c479b8e9f46aa0c0d8ed197ffee688b5f34a387d771c5a6f9
+//! 8e2ea6317cbdf0f9e223f9cc80af540004f985691c7789c1764ed6aabf61
+//! a6c28099abb65f602f40a825be32a33d9d070c796898d49d6349af205866
+//! 266f986b6d3234cd7d08155e1ad0000957ab303b2060c1dc1287d6f3e745
+//! 4f706709363155f220f66ca5156f2c8995691653817d31f1b6bd3742cc11
+//! 0bb2fc2b49a585b6fc767444936565
+//! ```
+//!
+//! You can generate that output with the command:
+//!
+//! ```text
+//! `xxd -ps mandelbrot_2048x2048_infohash_v1.png.torrent`.
+//! ```
+//!
+//! The same data can be represented in a JSON format:
+//!
+//! ```json
+//! {
+//!     "created by": "qBittorrent v4.4.1",
+//!     "creation date": 1679674628,
+//!     "info": {
+//!         "length": 172204,
+//!         "name": "mandelbrot_2048x2048.png",
+//!         "piece length": 16384,
+//!         "pieces": "<hex>7D 91 71 0D 9D 4D BA 88 9B 54 20 54 D5 26 72 8D 5A 86 3F E1 21 DF 77 C7 F7 BB 6C 77 96 21 66 25 38 C5 D9 CD AB 8B 08 EF 8C 24 9B B2 F5 C4 CD 2A DF 0B C0 0C F0 AD DF 72 90 E5 B6 41 4C 23 6C 47 9B 8E 9F 46 AA 0C 0D 8E D1 97 FF EE 68 8B 5F 34 A3 87 D7 71 C5 A6 F9 8E 2E A6 31 7C BD F0 F9 E2 23 F9 CC 80 AF 54 00 04 F9 85 69 1C 77 89 C1 76 4E D6 AA BF 61 A6 C2 80 99 AB B6 5F 60 2F 40 A8 25 BE 32 A3 3D 9D 07 0C 79 68 98 D4 9D 63 49 AF 20 58 66 26 6F 98 6B 6D 32 34 CD 7D 08 15 5E 1A D0 00 09 57 AB 30 3B 20 60 C1 DC 12 87 D6 F3 E7 45 4F 70 67 09 36 31 55 F2 20 F6 6C A5 15 6F 2C 89 95 69 16 53 81 7D 31 F1 B6 BD 37 42 CC 11 0B B2 FC 2B 49 A5 85 B6 FC 76 74 44 93</hex>"
+//!     }
+//! }
+//! ```
+//!
+//! The JSON object was generated with: <https://github.com/Chocobo1/bencode_online>
+//!
+//! As you can see, there is a `info` attribute:
+//!
+//! ```json
+//! {
+//!     "length": 172204,
+//!     "name": "mandelbrot_2048x2048.png",
+//!     "piece length": 16384,
+//!     "pieces": "<hex>7D 91 71 0D 9D 4D BA 88 9B 54 20 54 D5 26 72 8D 5A 86 3F E1 21 DF 77 C7 F7 BB 6C 77 96 21 66 25 38 C5 D9 CD AB 8B 08 EF 8C 24 9B B2 F5 C4 CD 2A DF 0B C0 0C F0 AD DF 72 90 E5 B6 41 4C 23 6C 47 9B 8E 9F 46 AA 0C 0D 8E D1 97 FF EE 68 8B 5F 34 A3 87 D7 71 C5 A6 F9 8E 2E A6 31 7C BD F0 F9 E2 23 F9 CC 80 AF 54 00 04 F9 85 69 1C 77 89 C1 76 4E D6 AA BF 61 A6 C2 80 99 AB B6 5F 60 2F 40 A8 25 BE 32 A3 3D 9D 07 0C 79 68 98 D4 9D 63 49 AF 20 58 66 26 6F 98 6B 6D 32 34 CD 7D 08 15 5E 1A D0 00 09 57 AB 30 3B 20 60 C1 DC 12 87 D6 F3 E7 45 4F 70 67 09 36 31 55 F2 20 F6 6C A5 15 6F 2C 89 95 69 16 53 81 7D 31 F1 B6 BD 37 42 CC 11 0B B2 FC 2B 49 A5 85 B6 FC 76 74 44 93</hex>"
+//!  }
+//! ```
+//!
+//! The infohash is the [SHA1](https://en.wikipedia.org/wiki/SHA-1) hash
+//! of the `info` attribute. That is, the SHA1 hash of:
+//!
+//! ```text
+//! 64363a6c656e6774686931373232303465343a6e61
+//! d6532343a6d616e64656c62726f745f3230343878323034382e706e6731
+//! 23a7069656365206c656e67746869313633383465363a70696563657332
+//! 2303a7d91710d9d4dba889b542054d526728d5a863fe121df77c7f7bb6c
+//! 79621662538c5d9cdab8b08ef8c249bb2f5c4cd2adf0bc00cf0addf7290
+//! 5b6414c236c479b8e9f46aa0c0d8ed197ffee688b5f34a387d771c5a6f9
+//! e2ea6317cbdf0f9e223f9cc80af540004f985691c7789c1764ed6aabf61
+//! 6c28099abb65f602f40a825be32a33d9d070c796898d49d6349af205866
+//! 66f986b6d3234cd7d08155e1ad0000957ab303b2060c1dc1287d6f3e745
+//! f706709363155f220f66ca5156f2c8995691653817d31f1b6bd3742cc11
+//! bb2fc2b49a585b6fc7674449365
+//! ```
+//!
+//! You can hash that byte string with <https://www.pelock.com/products/hash-calculator>
+//!
+//! The result is a 20-char string: `5452869BE36F9F3350CCEE6B4544E7E76CAAADAB`
+
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::panic::Location;
+
+use thiserror::Error;
+
+/// `BitTorrent` Info Hash v1
+#[derive(Default, PartialEq, Eq, Hash, Clone, Copy, Debug)]
+pub struct InfoHash(pub [u8; 20]);
+
+pub const INFO_HASH_BYTES_LEN: usize = 20;
+
+impl InfoHash {
+    /// Create a new `InfoHash` from a byte slice.
+    ///
+    /// # Panics
+    ///
+    /// Creates an `InfoHash` from a 20-byte slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the slice length is not exactly 20 bytes.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        assert_eq!(bytes.len(), INFO_HASH_BYTES_LEN, "expected 20 bytes for InfoHash");
+        let mut data = [0u8; INFO_HASH_BYTES_LEN];
+        data.copy_from_slice(bytes);
+        Self(data)
+    }
+
+    /// Returns the `InfoHash` internal byte array.
+    #[must_use]
+    pub const fn bytes(&self) -> [u8; 20] {
+        self.0
+    }
+
+    /// Returns the `InfoHash` as a hex string.
+    #[must_use]
+    pub fn to_hex_string(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Ord for InfoHash {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd<Self> for InfoHash {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::fmt::Display for InfoHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut chars = [0u8; 40];
+
+        let hex_result = binascii::bin2hex(&self.0, &mut chars).map_err(|_| std::fmt::Error)?;
+        let hex_str = std::str::from_utf8(hex_result).map_err(|_| std::fmt::Error)?;
+        write!(f, "{hex_str}")
+    }
+}
+
+impl std::str::FromStr for InfoHash {
+    type Err = binascii::ConvertError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut i = Self::default();
+
+        if s.len() != 40 {
+            return Err(binascii::ConvertError::InvalidInputLength);
+        }
+
+        binascii::hex2bin(s.as_bytes(), &mut i.0)?;
+
+        Ok(i)
+    }
+}
+
+impl From<&[u8]> for InfoHash {
+    fn from(data: &[u8]) -> Self {
+        assert_eq!(data.len(), 20);
+        let mut ret = Self::default();
+        ret.0.clone_from_slice(data);
+        ret
+    }
+}
+
+/// for testing
+impl From<&DefaultHasher> for InfoHash {
+    fn from(data: &DefaultHasher) -> Self {
+        let n = data.finish().to_le_bytes();
+        let bytes = [
+            n[0], n[1], n[2], n[3], n[4], n[5], n[6], n[7], n[0], n[1], n[2], n[3], n[4], n[5], n[6], n[7], n[0], n[1], n[2],
+            n[3],
+        ];
+        Self(bytes)
+    }
+}
+
+impl From<&i32> for InfoHash {
+    fn from(n: &i32) -> Self {
+        let n = n.to_le_bytes();
+        let bytes = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, n[0], n[1], n[2], n[3]];
+        Self(bytes)
+    }
+}
+
+impl From<[u8; 20]> for InfoHash {
+    fn from(bytes: [u8; 20]) -> Self {
+        Self(bytes)
+    }
+}
+
+/// Errors that can occur when converting from a `Vec<u8>` to an `InfoHash`.
+#[derive(Error, Debug)]
+pub enum ConversionError {
+    /// Not enough bytes for infohash. An infohash is 20 bytes.
+    #[error("not enough bytes for infohash: {message} {location}")]
+    NotEnoughBytes {
+        location: &'static Location<'static>,
+        message: String,
+    },
+    /// Too many bytes for infohash. An infohash is 20 bytes.
+    #[error("too many bytes for infohash: {message} {location}")]
+    TooManyBytes {
+        location: &'static Location<'static>,
+        message: String,
+    },
+}
+
+impl TryFrom<Vec<u8>> for InfoHash {
+    type Error = ConversionError;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        if bytes.len() < INFO_HASH_BYTES_LEN {
+            return Err(ConversionError::NotEnoughBytes {
+                location: Location::caller(),
+                message: format!("got {} bytes, expected {}", bytes.len(), INFO_HASH_BYTES_LEN),
+            });
+        }
+        if bytes.len() > INFO_HASH_BYTES_LEN {
+            return Err(ConversionError::TooManyBytes {
+                location: Location::caller(),
+                message: format!("got {} bytes, expected {}", bytes.len(), INFO_HASH_BYTES_LEN),
+            });
+        }
+        Ok(Self::from_bytes(&bytes))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl serde::ser::Serialize for InfoHash {
+    fn serialize<S: serde::ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut buffer = [0u8; 40];
+        let bytes_out = binascii::bin2hex(&self.0, &mut buffer).map_err(|e| serde::ser::Error::custom(format!("{e:?}")))?;
+        let str_out = std::str::from_utf8(bytes_out).map_err(|e| serde::ser::Error::custom(format!("{e:?}")))?;
+        serializer.serialize_str(str_out)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::de::Deserialize<'de> for InfoHash {
+    fn deserialize<D: serde::de::Deserializer<'de>>(des: D) -> Result<Self, D::Error> {
+        des.deserialize_str(InfoHashVisitor)
+    }
+}
+
+#[cfg(feature = "serde")]
+struct InfoHashVisitor;
+
+#[cfg(feature = "serde")]
+impl serde::de::Visitor<'_> for InfoHashVisitor {
+    type Value = InfoHash;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "a 40 character long hash")
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        if v.len() != 40 {
+            return Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(v),
+                &"a 40 character long string",
+            ));
+        }
+
+        let mut res = InfoHash::default();
+
+        if binascii::hex2bin(v.as_bytes(), &mut res.0).is_err() {
+            return Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(v),
+                &"a hexadecimal string",
+            ));
+        }
+        Ok(res)
+    }
+}
+
+pub mod fixture {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+
+    use super::InfoHash;
+
+    /// Generate as semi-stable pseudo-random infohash
+    ///
+    /// Note: If the [`DefaultHasher`] implementation changes
+    ///       so will the resulting info-hashes.
+    ///
+    /// The results should not be relied upon between versions.
+    #[must_use]
+    #[expect(dead_code, reason = "public fixture API for downstream consumers")]
+    pub fn gen_seeded_infohash(seed: u64) -> InfoHash {
+        let mut buf_a: [[u8; 8]; 4] = Default::default();
+        let mut buf_b = InfoHash::default();
+
+        let mut hasher = DefaultHasher::new();
+        seed.hash(&mut hasher);
+
+        for u in &mut buf_a {
+            seed.hash(&mut hasher);
+            *u = hasher.finish().to_le_bytes();
+        }
+
+        for (a, b) in buf_a.iter().flat_map(|a| a.iter()).zip(buf_b.0.iter_mut()) {
+            *b = *a;
+        }
+
+        buf_b
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::str::FromStr;
+
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    use super::InfoHash;
+
+    #[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+    struct ContainingInfoHash {
+        pub info_hash: InfoHash,
+    }
+
+    #[test]
+    fn an_info_hash_can_be_created_from_a_valid_40_utf8_char_string_representing_an_hexadecimal_value() {
+        let info_hash = InfoHash::from_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+        assert!(info_hash.is_ok());
+    }
+
+    #[test]
+    fn an_info_hash_can_not_be_created_from_a_utf8_string_representing_a_not_valid_hexadecimal_value() {
+        let info_hash = InfoHash::from_str("GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG");
+        assert!(info_hash.is_err());
+    }
+
+    #[test]
+    fn an_info_hash_can_only_be_created_from_a_40_utf8_char_string() {
+        let info_hash = InfoHash::from_str(&"F".repeat(39));
+        assert!(info_hash.is_err());
+
+        let info_hash = InfoHash::from_str(&"F".repeat(41));
+        assert!(info_hash.is_err());
+    }
+
+    #[test]
+    fn an_info_hash_should_by_displayed_like_a_40_utf8_lowercased_char_hex_string() {
+        let info_hash = InfoHash::from_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap();
+
+        let output = format!("{info_hash}");
+
+        assert_eq!(output, "ffffffffffffffffffffffffffffffffffffffff");
+    }
+
+    #[test]
+    fn an_info_hash_should_return_its_a_40_utf8_lowercased_char_hex_representations_as_string() {
+        let info_hash = InfoHash::from_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap();
+
+        assert_eq!(info_hash.to_hex_string(), "ffffffffffffffffffffffffffffffffffffffff");
+    }
+
+    #[test]
+    fn an_info_hash_can_be_created_from_a_valid_20_byte_array_slice() {
+        let info_hash: InfoHash = [255u8; 20].as_slice().into();
+
+        assert_eq!(
+            info_hash,
+            InfoHash::from_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap()
+        );
+    }
+
+    #[test]
+    fn an_info_hash_can_be_created_from_a_valid_20_byte_array() {
+        let info_hash: InfoHash = [255u8; 20].into();
+
+        assert_eq!(
+            info_hash,
+            InfoHash::from_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap()
+        );
+    }
+
+    #[test]
+    fn an_info_hash_can_be_created_from_a_byte_vector() {
+        let info_hash: InfoHash = [255u8; 20].to_vec().try_into().unwrap();
+
+        assert_eq!(
+            info_hash,
+            InfoHash::from_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap()
+        );
+    }
+
+    #[test]
+    fn it_should_fail_trying_to_create_an_info_hash_from_a_byte_vector_with_less_than_20_bytes() {
+        assert!(InfoHash::try_from([255u8; 19].to_vec()).is_err());
+    }
+
+    #[test]
+    fn it_should_fail_trying_to_create_an_info_hash_from_a_byte_vector_with_more_than_20_bytes() {
+        assert!(InfoHash::try_from([255u8; 21].to_vec()).is_err());
+    }
+
+    #[test]
+    fn an_info_hash_can_be_serialized() {
+        let s = ContainingInfoHash {
+            info_hash: InfoHash::from_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap(),
+        };
+
+        let json_serialized_value = serde_json::to_string(&s).unwrap();
+
+        assert_eq!(
+            json_serialized_value,
+            r#"{"info_hash":"ffffffffffffffffffffffffffffffffffffffff"}"#
+        );
+    }
+
+    #[test]
+    fn an_info_hash_can_be_deserialized() {
+        let json = json!({
+            "info_hash": "ffffffffffffffffffffffffffffffffffffffff",
+        });
+
+        let s: ContainingInfoHash = serde_json::from_value(json).unwrap();
+
+        assert_eq!(
+            s,
+            ContainingInfoHash {
+                info_hash: InfoHash::from_str("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF").unwrap()
+            }
+        );
+    }
+}

--- a/packages/info-hash/src/lib.rs
+++ b/packages/info-hash/src/lib.rs
@@ -1,0 +1,7 @@
+//! `BitTorrent` [`InfoHash`] v1 type for Rust crates.
+
+#![allow(clippy::module_name_repetitions)]
+
+mod info_hash;
+
+pub use self::info_hash::InfoHash;

--- a/project-words.txt
+++ b/project-words.txt
@@ -11,11 +11,13 @@ Behaviour
 behaviour
 bencode
 bencoded
+binascii
 bitcomet
 bitfield
 btih
 byteorder
 canonicalize
+Celano
 castagnoli
 checkin
 checksummed
@@ -49,9 +51,11 @@ frontmatter
 handshaken
 hasher
 heartbeating
+hexlify
 holepunch
 impls
 infohash
+infohashes
 ISCSI
 josecelano
 kademlia


### PR DESCRIPTION
## Summary

Completes the import of `torrust-info-hash` v0.1.0 from the original `torrust/bittorrent-primitives` repository into the torrust-bittorrent monorepo.

## Changes

- Import torrust-info-hash v0.1.0 as a new workspace package with faithful preservation of the original implementation
- Add info-hash to workspace members in Cargo.toml for proper workspace integration
- Update project documentation (AGENTS.md) with info-hash entry in the package table
- Fix clippy lint violations to meet workspace strict lint policies
- Update project-words.txt with technical terms
- Fix README.md markdown emphasis style compliance

## Verification

✅ All clippy lints pass
✅ All tests pass (267/267 via cargo-nextest)
✅ All linters pass (`linter all`)
✅ Formatting verified
✅ Documentation compiles

Closes #87